### PR TITLE
Skip individual image builds when possible

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,12 +46,15 @@ test_image_build_task:
                 - env:
                       REPO_NAME: podman
                       CTX_SUB: podman/$FLAVOR_NAME
+                      skip: "!changesInclude('.cirrus.yml', 'podman/**/*')"
                 - env:
                       REPO_NAME: buildah
                       CTX_SUB: buildah
+                      skip: "!changesInclude('.cirrus.yml', 'buildah/**/*')"
                 - env:
                       REPO_NAME: skopeo
                       CTX_SUB: skopeo/$FLAVOR_NAME
+                      skip: "!changesInclude('.cirrus.yml', 'skopeo/**/*')"
         - env:
               FLAVOR_NAME: testing
           matrix: *pbs_images


### PR DESCRIPTION
These builds can take quite some time to complete.  Add some skip logic such that only images with changed content are built in CI.