### PR TITLE
Relocate sample usage details

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,6 @@ Monorepo menagerie of container images and associated build automation
 
 ## Overview
 
-[comment]: <> (***ATTENTION*** ***WARNING*** ***ALERT*** ***CAUTION*** ***DANGER***)
-[comment]: <> ()
-[comment]: <> (ANY changes made below, once committed/merged must)
-[comment]: <> (be manually copy/pasted -in markdown- into the description)
-[comment]: <> (field on Quay at the following locations, where * represents podman|buildah|skopeo:)
-[comment]: <> ()
-[comment]: <> (https://quay.io/repository/containers/*)
-[comment]: <> (https://quay.io/repository/*/stable)
-[comment]: <> (https://quay.io/repository/*/testing)
-[comment]: <> (https://quay.io/repository/*/upstream)
-[comment]: <> ()
-[comment]: <> (***ATTENTION*** ***WARNING*** ***ALERT*** ***CAUTION*** ***DANGER***)
-
 The latest version of these docs may be obtained from [the upstream
 repo.](https://github.com/containers/image_build/blob/main/README.md)
 
@@ -53,100 +40,12 @@ or `skopeo`:
 
 ## Podman Sample Usage
 
-![PODMAN logo](https://raw.githubusercontent.com/containers/common/main/logos/podman-logo-full-vert.png)
-
-```
-podman pull docker://quay.io/podman/stable:latest
-
-podman run --privileged stable podman version
-
-# Create a directory on the host to mount the container's
-# /var/lib/container directory to so containers can be
-# run within the container.
-mkdir /var/lib/mycontainer
-
-# Run the image detached using the host's network in a container name
-# podmanctr, turn off label and seccomp confinement in the container
-# and then do a little shell hackery to keep the container up and running.
-podman run --detach --name=podmanctr --net=host --security-opt label=disable --security-opt seccomp=unconfined --device /dev/fuse:rw -v /var/lib/mycontainer:/var/lib/containers:Z --privileged  stable sh -c 'while true ;do sleep 100000 ; done'
-
-podman exec -it  podmanctr /bin/sh
-
-# Now inside of the container
-
-podman pull alpine
-
-podman images
-
-exit
-```
-
-**Note:** If you encounter a `fuse: device not found` error when running the container image, it is likely that
-the fuse kernel module has not been loaded on your host system.  Use the command `modprobe fuse` to load the
-module and then run the container image.  To enable this automatically at boot time, you can add a configuration
-file to `/etc/modules.load.d`.  See `man modules-load.d` for more details.
-
-More details:
-
-Dan Walsh wrote a blog post on the [Enable Sysadmin](https://www.redhat.com/sysadmin/) site titled [How to use Podman inside of a container](https://www.redhat.com/sysadmin/podman-inside-container).  In it, he details how to use these images as a rootful and as a rootless user.  Please refer to this blog for more detailed information.
-
+[Please see the subdirectory README.md](https://github.com/containers/image_build/blob/main/podman/README.md)
 
 ## Buildah Sample Usage
 
-![buildah logo](https://cdn.rawgit.com/containers/buildah/main/logos/buildah-logo_large.png)
-
-Although not required, it is suggested that [Podman](https://github.com/containers/podman) be used with
-these container images.
-
-```
-podman pull docker://quay.io/buildah/stable:latest
-
-podman run stable buildah version
-
-# Create a directory on the host to mount the container's
-# /var/lib/container directory to so containers can be
-# run within the container.
-mkdir /var/lib/mycontainer
-
-# Run the image detached using the host's network in a container name
-# buildahctr, turn off label and seccomp confinement in the container
-# and then do a little shell hackery to keep the container up and running.
-podman run --detach --name=buildahctr --net=host --security-opt label=disable --security-opt seccomp=unconfined --device /dev/fuse:rw -v /var/lib/mycontainer:/var/lib/containers:Z  stable sh -c 'while true ;do sleep 100000 ; done'
-
-podman exec -it  buildahctr /bin/sh
-
-# Now inside of the container
-
-buildah from alpine
-
-buildah images
-
-exit
-```
-
-**Note:** If you encounter a `fuse: device not found` error when running the container image, it is likely that
-the fuse kernel module has not been loaded on your host system.  Use the command `modprobe fuse` to load the
-module and then run the container image.  To enable this automatically at boot time, you can add a configuration
-file to `/etc/modules.load.d`.  See `man modules-load.d` for more details.
-
+[Please see the subdirectory README.md](https://github.com/containers/image_build/blob/main/buildah/README.md)
 
 ## Skopeo Sample Usage
 
-<img src="https://cdn.rawgit.com/containers/skopeo/main/docs/skopeo.svg" width="250">
-
-Although not required, it is suggested that [Podman](https://github.com/containers/podman) be used with these container images.
-
-```
-# Get Help on Skopeo
-podman run docker://quay.io/skopeo/stable:latest --help
-
-# Get help on the Skopeo Copy command
-podman run docker://quay.io/skopeo/stable:latest copy --help
-
-# Copy the Skopeo container image from quay.io to
-# a private registry
-podman run docker://quay.io/skopeo/stable:latest copy docker://quay.io/skopeo/stable docker://registry.internal.company.com/skopeo
-
-# Inspect the fedora:latest image
-podman run docker://quay.io/skopeo/stable:latest inspect --config docker://registry.fedoraproject.org/fedora:latest  | jq
-```
+[Please see the subdirectory README.md](https://github.com/containers/image_build/blob/main/skopeo/README.md)

--- a/buildah/README.md
+++ b/buildah/README.md
@@ -1,6 +1,6 @@
 [comment]: <> (***ATTENTION*** ***WARNING*** ***ALERT*** ***CAUTION*** ***DANGER***)
 [comment]: <> ()
-[comment]: <> (ANY changes made to this file, once committed/merged must)
+[comment]: <> (ANY changes made below, once committed/merged must)
 [comment]: <> (be manually copy/pasted -in markdown- into the description)
 [comment]: <> (field on Quay at the following locations:)
 [comment]: <> ()
@@ -13,42 +13,12 @@
 
 ![buildah logo](https://cdn.rawgit.com/containers/buildah/main/logos/buildah-logo_large.png)
 
-# buildahimage
+# Buildah Image
 
-## Overview
+## Build information
 
-This directory contains the Dockerfiles necessary to create the buildahimage container
-images that are housed on quay.io under the buildah account.  All repositories where
-the images live are public and can be pulled without credentials.  These container images are secured and the
-resulting containers can run safely with privileges within the container.
-
-The container images are built using the latest Fedora and then Buildah is installed into them.
-The PATH in the container images is set to the default PATH provided by Fedora.  Also, the
-ENTRYPOINT and the WORKDIR variables are not set within these container images, as such they
-default to `/`.
-
-The container images are:
-
-  * `quay.io/containers/buildah:<version>` and `quay.io/buildah/stable:<version>` -
-    These images are built daily. They are intended to contain an unchanging
-    and stable version of buildah.  For the most recent `<version>` tags (`vX`,
-    `vX.Y`, and `vX.Y.Z`) the image contents will be updated daily to incorporate
-    (especially) security upgrades.  For build details, please [see the
-    configuration file](stable/Dockerfile).
-  * `quay.io/containers/buildah:latest` and `quay.io/buildah/stable:latest` -
-    Built daily using the same Dockerfile as above.  The buildah version
-    will remain the "latest" available in Fedora, however the other image
-    contents may vary compared to the version-tagged images.
-  * `quay.io/buildah/testing:latest` - This image is built daily, using the
-    latest version of Buildah that was in the Fedora `updates-testing` repository.
-    The image is Built with [the testing Dockerfile](testing/Dockerfile).
-  * `quay.io/buildah/upstream:latest` - This image is built daily using the latest
-    code found in this GitHub repository.  Due to the image changing frequently,
-    it's not guaranteed to be stable or even executable.  The image is built with
-    [the upstream Dockerfile](upstream/Dockerfile).  Note: The actual compilation
-    of upstream buildah [occurs continuously in
-    COPR](https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/).
-
+Please see the [top-level image_build repo. README.md for build
+details](https://github.com/containers/image_build/blob/main/README.md).
 
 ## Sample Usage
 

--- a/podman/README.md
+++ b/podman/README.md
@@ -1,56 +1,26 @@
 [comment]: <> (***ATTENTION*** ***WARNING*** ***ALERT*** ***CAUTION*** ***DANGER***)
 [comment]: <> ()
-[comment]: <> (ANY changes made to this file, once committed/merged must)
+[comment]: <> (ANY changes made below, once committed/merged must)
 [comment]: <> (be manually copy/pasted -in markdown- into the description)
 [comment]: <> (field on Quay at the following locations:)
 [comment]: <> ()
-[comment]: <> (https://quay.io/repository/containers/podman)
-[comment]: <> (https://quay.io/repository/podman/stable)
-[comment]: <> (https://quay.io/repository/podman/testing)
-[comment]: <> (https://quay.io/repository/podman/upstream)
+[comment]: <> (https://quay.io/repository/containers/skopeo)
+[comment]: <> (https://quay.io/repository/skopeo/stable)
+[comment]: <> (https://quay.io/repository/skopeo/testing)
+[comment]: <> (https://quay.io/repository/skopeo/upstream)
 [comment]: <> ()
 [comment]: <> (***ATTENTION*** ***WARNING*** ***ALERT*** ***CAUTION*** ***DANGER***)
 
 ![PODMAN logo](https://raw.githubusercontent.com/containers/common/main/logos/podman-logo-full-vert.png)
 
-# podmanimage
+# Podman Image
 
-## Overview
+## Build information
 
-This directory contains the Containerfiles necessary to create the podmanimage container
-images that are housed on quay.io under the Podman account.  All repositories where
-the images live are public and can be pulled without credentials.  These container images are secured and the
-resulting containers can run safely with privileges within the container.
-
-The container images are built using the latest Fedora and then Podman is installed into them.
-The PATH in the container images is set to the default PATH provided by Fedora.  Also, the
-ENTRYPOINT and the WORKDIR variables are not set within these container images, as such they
-default to `/`.
-
-The container images are:
-
-  * `quay.io/containers/podman:<version>` and `quay.io/podman/stable:<version>` -
-    These images are built daily.  They are intended to contain an unchanging
-    and stable version of podman. For the most recent `<version>` tags (`vX`,
-    `vX.Y`, and `vX.Y.Z`) the image contents will be updated daily to incorporate
-    (especially) security upgrades.  For build details, please [see the
-    configuration file](stable/Containerfile).
-  * `quay.io/containers/podman:latest` and `quay.io/podman/stable:latest` -
-    Built daily using the same Containerfile as above.  The Podman version
-    will remain the "latest" available in Fedora, however the other image
-    contents may vary compared to the version-tagged images.
-  * `quay.io/podman/testing:latest` - This image is built daily, using the
-    latest version of Podman that was in the Fedora `updates-testing` repository.
-    The image is Built with [the testing Containerfile](testing/Containerfile).
-  * `quay.io/podman/upstream:latest` - This image is built daily using the latest
-    code found in this GitHub repository.  Due to the image changing frequently,
-    it's not guaranteed to be stable or even executable.  The image is built with
-    [the upstream Containerfile](upstream/Containerfile). Note the actual compilation
-    of upstream podman [occurs continuously in
-    COPR](https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/).
+Please see the [top-level image_build repo. README.md for build
+details](https://github.com/containers/image_build/blob/main/README.md).
 
 ## Sample Usage
-
 
 ```
 podman pull docker://quay.io/podman/stable:latest

--- a/skopeo/README.md
+++ b/skopeo/README.md
@@ -1,6 +1,6 @@
 [comment]: <> (***ATTENTION*** ***WARNING*** ***ALERT*** ***CAUTION*** ***DANGER***)
 [comment]: <> ()
-[comment]: <> (ANY changes made to this file, once committed/merged must)
+[comment]: <> (ANY changes made below, once committed/merged must)
 [comment]: <> (be manually copy/pasted -in markdown- into the description)
 [comment]: <> (field on Quay at the following locations:)
 [comment]: <> ()
@@ -13,40 +13,12 @@
 
 <img src="https://cdn.rawgit.com/containers/skopeo/main/docs/skopeo.svg" width="250">
 
-----
+# Skopeo Image
 
-# skopeoimage
+## Build information
 
-## Overview
-
-This directory contains the Containerfiles necessary to create the skopeoimage container
-images that are housed on quay.io under the skopeo account.  All repositories where
-the images live are public and can be pulled without credentials.  These container images are secured and the
-resulting containers can run safely with privileges within the container.
-
-The container images are built using the latest Fedora and then Skopeo is installed into them.
-The ENTRYPOINT of the container is set to execute the `skopeo` binary.
-
-The container images are:
-
-  * `quay.io/containers/skopeo:v<version>` and `quay.io/skopeo/stable:v<version>` -
-    These images are built daily.  These images are intended contain an unchanging
-    and stable version of skopeo.  For the most recent `<version>` tags (`vX`,
-    `vX.Y`, and `vX.Y.Z`) the image contents will be updated daily to incorporate
-    (especially) security updates.  For build details, please[see the configuration
-    file](stable/Containerfile).
-  * `quay.io/containers/skopeo:latest` and `quay.io/skopeo/stable:latest` -
-    Built daily using the same Containerfile as above.  The skopeo version
-    will remain the "latest" available in Fedora, however the other image
-    contents may vary compared to the version-tagged images.
-  * `quay.io/skopeo/testing:latest` - This image is built daily, using the
-    latest version of Skopeo that was in the Fedora `updates-testing` repository.
-    The image is Built with [the testing Containerfile](testing/Containerfile).
-  * `quay.io/skopeo/upstream:latest` - This image is built daily using the latest
-    code found in this GitHub repository.  Due to the image changing frequently,
-    it's not guaranteed to be stable or even executable.  The image is built with
-    [the upstream Containerfile](upstream/Containerfile).
-
+Please see the [top-level image_build repo. README.md for build
+details](https://github.com/containers/image_build/blob/main/README.md).
 
 ## Sample Usage
 


### PR DESCRIPTION
Replace all the p|b|s subdirectory `README.md` contents with just the sample usage.  Also include a link to the combined build-info section of the top-level `README.md`.