### PR TITLE
Migrate build script from c/automation_images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,18 +25,32 @@ validate_task:
         - "ci/shellcheck.sh"
         - "ci/validate.sh"
 
+test_build-push_task:
+    name: "Test build-push scripts function"
+    alias: test_build-push
+    only_if: *is_pr
+    # No need to test if changes don't include ...
+    skip: "!changesInclude('.cirrus.yml', 'build-push/**/*')"
+    depends_on:
+        - validate
+    gce_instance: &build_push_test_vm
+        image_project: "libpod-218412"
+        image_family: 'build-push-cache'
+        zone: "us-central1-a"
+        disk: 200
+    script: |
+      bash ./build-push/.install.sh
+      bash ./build-push/test.sh
+
 test_image_build_task:
     alias: test_image_build
     name: Test build ${REPO_NAME}/${FLAVOR_NAME} image
     only_if: *is_pr
-    # No need to test if changes don't include ...
-    skip: "!changesInclude('.cirrus.yml', 'podman/**/*', 'buildah/**/*', 'skopeo/**/*')"
+    depends_on:
+        - test_build-push
     gce_instance: &build_push
-        image_project: "libpod-218412"
-        image_family: 'build-push-cache'
-        zone: "us-central1-a"
+        <<: *build_push_test_vm
         type: "t2d-standard-4"  # Extra muscle needed for multi-arch emulation
-        disk: 200
     env:
         ARCHES: amd64
         DRYRUN: 1  # Don't actually push anything, only build.
@@ -48,15 +62,15 @@ test_image_build_task:
                 - env:
                       REPO_NAME: podman
                       CTX_SUB: podman/$FLAVOR_NAME
-                      skip: "!changesInclude('.cirrus.yml', 'podman/**/*')"
+                      skip: "!changesInclude('.cirrus.yml', 'build-push/**/*', 'podman/**/*')"
                 - env:
                       REPO_NAME: buildah
                       CTX_SUB: buildah
-                      skip: "!changesInclude('.cirrus.yml', 'buildah/**/*')"
+                      skip: "!changesInclude('.cirrus.yml', 'build-push/**/*', 'buildah/**/*')"
                 - env:
                       REPO_NAME: skopeo
                       CTX_SUB: skopeo/$FLAVOR_NAME
-                      skip: "!changesInclude('.cirrus.yml', 'skopeo/**/*')"
+                      skip: "!changesInclude('.cirrus.yml', 'build-push/**/*', 'skopeo/**/*')"
         - env:
               FLAVOR_NAME: testing
           matrix: *pbs_images
@@ -64,8 +78,7 @@ test_image_build_task:
               FLAVOR_NAME: stable
           matrix: *pbs_images
     script: &pbs_script |
-        git clone --depth=1 https://github.com/containers/automation_images.git ../ai
-        bash ../ai/build-push/.install.sh
+        bash ./build-push/.install.sh
         source /etc/automation_environment
         # The '.' prefix to repo URL is significant - it means do not clone.
         containers_build_push.sh .${REPO_PREFIX}/${REPO_NAME}.git $CTX_SUB $FLAVOR_NAME
@@ -93,6 +106,7 @@ success_task:
     only_if: *is_pr
     depends_on:
         - validate
+        - test_build-push
         - test_image_build
     container:
         <<: *ci_container

--- a/build-push/.install.sh
+++ b/build-push/.install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This script is intended to be run from a task using a pre-existing
+# build-push VM image (having an image-suffix from the IMG_SFX file).
+# It's purpose is to install the latest version of the scripts in the
+# `bin` directory onto the system.
+#
+# WARNING: Use under any other circumstances will probably screw things up.
+
+# Common automation library pre-installed into the build-push VM
+if [[ -r /etc/automation_environment ]]; then
+    # Defines AUTOMATION_LIB_PATH and updates PATH
+    source /etc/automation_environment
+    source "$AUTOMATION_LIB_PATH/common_lib.sh"
+else
+    echo "ERROR: The common automation library has not been installed." > /dev/stderr
+    exit 1
+fi
+
+# Defined by common automation library
+# shellcheck disable=SC2154
+cd $(dirname "${BASH_SOURCE[0]}") || exit 1
+
+# Must be installed into $AUTOMATION_LIB_PATH/../bin which is also now on $PATH
+install -g root -o root -m 550 ./bin/* $AUTOMATION_LIB_PATH/../bin/

--- a/build-push/README.md
+++ b/build-push/README.md
@@ -1,0 +1,4 @@
+# DO NOT USE
+
+This directory contains scripts/data used by several Cirrus-CI
+tasks.  It is not intended to be used otherwise and may cause harm.

--- a/build-push/bin/containers_build_push.sh
+++ b/build-push/bin/containers_build_push.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+
+# This script is not intended for humans.  It should be run by secure
+# (maintainer-only) cron-like automation to service the skopeo, buildah,
+# and podman repositories.  It's purpose is to produce a multi-arch container
+# image based on the contents of a repository context subdirectory from their
+# respective 'main' branches.
+#
+# The first argument to the script, should be the git URL of the repository
+# containing the build context.  If prefixed by a '.' character, the repository
+# will not be cloned, and instead $CWD will be used.  In all cases this URL will
+# be used to add several labels the produced images.
+#
+# The second argument to this script is the relative path to the build context
+# subdirectory.  The basename of this subdirectory may (see next paragraph)
+# indicate the image flavor (i.e. `upstream`, `testing`, or `stable`). Depending
+# on this value, the image may be pushed to multiple container registries
+# under slightly different rules (see the next option).
+#
+# If the basename of the context directory (second argument) does NOT reflect
+# the image flavor, this name may be passed in as a third argument.  Handling
+# of this argument may be repository-specific, so check the actual code below
+# to understand it's behavior.
+
+set -eo pipefail
+
+if [[ -r "/etc/automation_environment" ]]; then
+    source /etc/automation_environment  # defines AUTOMATION_LIB_PATH
+    #shellcheck disable=SC1090,SC2154
+    source "$AUTOMATION_LIB_PATH/common_lib.sh"
+    dbg "Using automation common library version $(<$AUTOMATION_LIB_PATH/../AUTOMATION_VERSION)"
+else
+    echo "Expecting to find automation common library installed."
+    exit 1
+fi
+
+if [[ -z $(type -P build-push.sh) ]]; then
+    die "It does not appear that build-push.sh is installed properly"
+fi
+
+if [[ -z "$1" ]]; then
+    die "Expecting a git repository URI as the first argument."
+fi
+
+# Careful: Changing the error message below could break auto-update test.
+if [[ "$#" -lt 2 ]]; then
+    #shellcheck disable=SC2145
+    die "Must be called with at least two arguments, got '$*'"
+fi
+
+req_env_vars CI
+
+# Assume transitive debugging state for build-push.sh if set
+if [[ "$(automation_version | cut -d '.' -f 1)" -ge 4 ]]; then
+    # Valid for version 4.0.0 and above only
+    export A_DEBUG
+else
+    export DEBUG
+fi
+
+# Arches to build by default - may be overridden for testing
+ARCHES="${ARCHES:-amd64,ppc64le,s390x,arm64}"
+
+# First arg (REPO_URL) is the clone URL for repository for informational purposes
+REPO_URL="$1"
+[[ "${REPO_URL:0:1}" != "." ]] || \
+    REPO_URL="${1:1}"
+
+REPO_NAME=$(basename "${REPO_URL%.git}")
+
+if [[ ! "$REPO_URL" =~ github\.com ]] && [[ ! "$REPO_URL" =~ testing ]]; then
+  die "Script requires a repo hosted on github, received '$REPO_URL'."
+fi
+
+# Second arg (CTX_SUB) is the context subdirectory relative to the clone path
+CTX_SUB="$2"
+# Historically, the basename of second arg set the image flavor(i.e. `upstream`,
+# `testing`, or `stable`).  For cases where this convention doesn't fit,
+# it's possible to pass the flavor-name as the third argument.  Both methods
+# will populate a "FLAVOR" build-arg value.
+if [[ "$#" -lt 3 ]]; then
+    FLAVOR_NAME=$(basename "$CTX_SUB")
+elif [[ "$#" -ge 3 ]]; then
+    FLAVOR_NAME="$3"  # An empty-value is valid
+else
+    die "Expecting a non-empty third argument indicating the FLAVOR build-arg value."
+fi
+_REG="quay.io"
+if [[ "$REPO_NAME" =~ testing ]]; then
+    dbg "Unittests are running, using example/test registry name."
+    _REG="example.com"
+fi
+REPO_FQIN="$_REG/$REPO_NAME/$FLAVOR_NAME"
+req_env_vars REPO_URL REPO_NAME CTX_SUB FLAVOR_NAME
+
+# Common library defines SCRIPT_FILENAME
+# shellcheck disable=SC2154
+dbg "$SCRIPT_FILENAME operating constants:
+    REPO_URL=$REPO_URL
+    REPO_NAME=$REPO_NAME
+    CTX_SUB=$CTX_SUB
+    FLAVOR_NAME=$FLAVOR_NAME
+    REPO_FQIN=$REPO_FQIN
+"
+
+# Set non-zero to avoid actually executing build-push, simply print
+# the command-line that would have been executed
+DRYRUN=${DRYRUN:-0}
+_DRNOPUSH=""
+if ((DRYRUN)); then
+    _DRNOPUSH="--nopush"
+    warn "Operating in dry-run mode with $_DRNOPUSH"
+fi
+
+if [[ "${1:0:1}" != "." ]]; then
+    dbg "Cloning $REPO_URL and using its $CTX_SUB as build context"
+    # SCRIPT_PATH defined by automation library
+    # shellcheck disable=SC2154
+    CLONE_TMP=$(mktemp -p "" -d "tmp_${SCRIPT_FILENAME}_XXXX")
+    trap "rm -rf '$CLONE_TMP'" EXIT
+    showrun git clone --depth 1 "$REPO_URL" "$CLONE_TMP"
+    cd "$CLONE_TMP"
+else
+    dbg "Not cloning, using $PWD/$CTX_SUB as build context"
+fi
+
+### MAIN
+
+declare -a build_args
+if [[ -n "$FLAVOR_NAME" ]]; then
+    build_args=("--build-arg=FLAVOR=$FLAVOR_NAME")
+fi
+
+head_sha=$(git rev-parse HEAD)
+dbg "HEAD is $head_sha"
+
+# Docs should always be in one of two places, otherwise don't list any.
+DOCS_URL=""
+for _docs_subdir in "$CTX_SUB/README.md" "$(dirname $CTX_SUB)/README.md"; do
+    if [[ -r "./$_docs_subdir" ]]; then
+        dbg "Found README.md under '$CLONE_TMP/$_docs_subdir'"
+        DOCS_URL="${REPO_URL%.git}/blob/${head_sha}/$_docs_subdir"
+    fi
+done
+
+req_env_vars CIRRUS_TASK_ID CIRRUS_CHANGE_IN_REPO CIRRUS_REPO_NAME
+
+# Labels to add to all images as per
+# https://specs.opencontainers.org/image-spec/annotations/?v=v1.0.1
+declare -a label_args
+
+# Use both labels and annotations since some older tools only support labels
+# CIRRUS_TASK_ID provided by CI and verified non-empty
+# shellcheck disable=SC2154
+for arg in "--label" "--annotation"; do
+  label_args+=(\
+    # Avoid any ambiguity as to the source that produced the image.
+    # This requires REPO_URL is hosted on github (validated above)
+    "$arg=org.opencontainers.image.source=${REPO_URL%.git}/blob/${head_sha}/${CTX_SUB}/"
+    "$arg=org.opencontainers.image.revision=$head_sha"
+    "$arg=org.opencontainers.image.created=$(date -u --iso-8601=seconds)"
+    "$arg=org.opencontainers.image.authors=podman@lists.podman.io"
+  )
+
+  if [[ -n "$DOCS_URL" ]]; then
+    label_args+=(\
+      "$arg=org.opencontainers.image.documentation=${DOCS_URL}"
+    )
+  fi
+
+  # Perhaps slightly outside the intended purpose, but it kind of fits, and may help
+  # somebody ascertain provenance a little better.  Note: Even if the console logs
+  # are blank, the Cirrus-CI GraphQL API keeps build and task metadata for years.
+  label_args+=(\
+    "$arg=org.opencontainers.image.url=https://cirrus-ci.com/task/$CIRRUS_TASK_ID"
+  )
+
+  # Definitely not any official spec., but offers a quick reference to exactly what produced
+  # the images and it's current signature.
+  label_args+=(\
+    "$arg=built.by.repo=${CIRRUS_REPO_NAME}"
+    "$arg=built.by.commit=${CIRRUS_CHANGE_IN_REPO}"
+    "$arg=built.by.exec=$(basename ${BASH_SOURCE[0]})"
+    "$arg=built.by.digest=sha256:$(sha256sum<${BASH_SOURCE[0]} | awk '{print $1}')"
+  )
+done
+
+modcmdarg="tag_version.sh $FLAVOR_NAME"
+
+# For stable images, the version number of the command is needed for tagging and labeling.
+if [[ "$FLAVOR_NAME" == "stable" ]]; then
+    # only native arch is needed to extract the version
+    dbg "Building temporary local-arch image to extract stable version number"
+    FQIN_TMP="$REPO_NAME:temp"
+    showrun podman build -t $FQIN_TMP "${build_args[@]}" ./$CTX_SUB
+
+    case "$REPO_NAME" in
+        skopeo) version_cmd="--version" ;;
+        buildah) version_cmd="buildah --version" ;;
+        podman) version_cmd="podman --version" ;;
+        testing) version_cmd="cat FAKE_VERSION" ;;
+        *) die "Unknown/unsupported repo '$REPO_NAME'" ;;
+    esac
+
+    pvcmd="podman run -i --rm $FQIN_TMP $version_cmd"
+    dbg "Extracting version with command: $pvcmd"
+    version_output=$($pvcmd)
+    dbg "version output: '$version_output'"
+    img_cmd_version=$(awk -r -e '/^.+ version /{print $3}' <<<"$version_output")
+    dbg "parsed version: $img_cmd_version"
+    test -n "$img_cmd_version"
+
+    label_args+=("--label=org.opencontainers.image.version=$img_cmd_version"
+                 "--annotation=org.opencontainers.image.version=$img_cmd_version")
+
+    # tag-version.sh expects this arg. when FLAVOR_NAME=stable
+    modcmdarg+=" $img_cmd_version"
+
+    dbg "Building stable-flavor manifest-list '$_REG/containers/$REPO_NAME'"
+
+    # Stable images get pushed to 'containers' namespace as latest & version-tagged
+    showrun build-push.sh \
+        $_DRNOPUSH \
+        --arches="$ARCHES" \
+        --modcmd="$modcmdarg" \
+        "$_REG/containers/$REPO_NAME" \
+        "./$CTX_SUB" \
+        "${build_args[@]}" \
+        "${label_args[@]}"
+elif [[ "$FLAVOR_NAME" == "testing" ]]; then
+    label_args+=("--label=quay.expires-after=30d"
+                 "--annotation=quay.expires-after=30d")
+elif [[ "$FLAVOR_NAME" == "upstream" ]]; then
+    label_args+=("--label=quay.expires-after=15d"
+                 "--annotation=quay.expires-after=15d")
+fi
+
+dbg "Building manifest-list '$REPO_FQIN'"
+
+# All images are pushed to quay.io/<reponame>, both
+# latest and version-tagged (if available).
+showrun build-push.sh \
+    $_DRNOPUSH \
+    --arches="$ARCHES" \
+    --modcmd="$modcmdarg" \
+    "$REPO_FQIN" \
+    "./$CTX_SUB" \
+    "${build_args[@]}" \
+    "${label_args[@]}"

--- a/build-push/bin/tag_version.sh
+++ b/build-push/bin/tag_version.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# This script is not intended for humans.  It should only be referenced
+# as an argument to the build-push.sh `--modcmd` option.  It's purpose
+# is to ensure stable images are re-tagged with a verison-number
+# using a specific scheme, cooresponding to the included tool's version.
+# It expects two arguments, the first is the "flavor" of the image.
+# Typically 'upstream', 'testing', or 'stable'.  The second argument
+# is optional, when provided it should be the container-image's tool
+# version number (e.g. podman version).
+
+set -eo pipefail
+
+if [[ -r "/etc/automation_environment" ]]; then
+    source /etc/automation_environment  # defines AUTOMATION_LIB_PATH
+    #shellcheck disable=SC1090,SC2154
+    source "$AUTOMATION_LIB_PATH/common_lib.sh"
+else
+    echo "Unexpected operating environment"
+    exit 1
+fi
+
+# Vars defined by build-push.sh spec. for mod scripts
+req_env_vars SCRIPT_FILENAME SCRIPT_FILEPATH RUNTIME PLATFORMOS FQIN CONTEXT \
+             PUSH ARCHES REGSERVER NAMESPACE IMGNAME MODCMD
+
+if [[ "$#" -lt 1 ]]; then
+    # Defined by common automation library
+    # shellcheck disable=SC2154
+    die "$SCRIPT_FILENAME expects at least one argument"
+fi
+
+if [[ "$#" -ge 2 ]]; then
+    FLAVOR_NAME="$1"
+    # Version is optional
+    unset VERSION
+    [[ -z "$2" ]] || \
+        VERSION="v${2#v}"
+fi
+
+if [[ -z "$FLAVOR_NAME" ]]; then
+    # Defined by common_lib.sh
+    # shellcheck disable=SC2154
+    warn "$SCRIPT_FILENAME passed empty flavor-name argument."
+elif [[ -z "$VERSION" ]]; then
+    warn "$SCRIPT_FILENAME received empty version argument."
+fi
+
+# shellcheck disable=SC2154
+dbg "$SCRIPT_FILENAME operating on '$FLAVOR_NAME' flavor of '$FQIN' with tool version '$VERSION' (optional)"
+
+if [[ "$FLAVOR_NAME" == "stable" ]]; then
+    # Stable images must all be tagged with a version number.
+    # Confirm this value is passed in by caller.
+    if grep -E -q '^v[0-9]+\.[0-9]+\.[0-9]+'<<<"$VERSION"; then
+        msg "Using provided image command version '$VERSION'"
+    else
+        die "Encountered unexpected/non-conforming version '$VERSION'"
+    fi
+
+    # shellcheck disable=SC2154
+    $RUNTIME tag $FQIN:latest $FQIN:$VERSION
+    msg "Successfully tagged $FQIN:$VERSION"
+
+    # Tag as x.y to provide a consistent tag even for a future z+1
+    xy_ver=$(awk -F '.' '{print $1"."$2}'<<<"$VERSION")
+    $RUNTIME tag $FQIN:latest $FQIN:$xy_ver
+    msg "Successfully tagged $FQIN:$xy_ver"
+
+    # Tag as x to provide consistent tag even for a future y+1
+    x_ver=$(awk -F '.' '{print $1}'<<<"$xy_ver")
+    $RUNTIME tag $FQIN:latest $FQIN:$x_ver
+    msg "Successfully tagged $FQIN:$x_ver"
+else
+    warn "$SCRIPT_FILENAME not version-tagging for '$FLAVOR_NAME' flavor'$FQIN'"
+fi

--- a/build-push/test.sh
+++ b/build-push/test.sh
@@ -1,0 +1,185 @@
+
+
+# DO NOT USE - This script is intended to be called by the Cirrus-CI
+# `test_build-push` task.  It is not intended to be used otherwise
+# and may cause harm.  It's purpose is to confirm the
+# 'containers_build_push.sh' script behaves in an expected way, given
+# a special testing git repository (setup here) as input.
+
+set -eo pipefail
+
+source /etc/automation_environment
+source $AUTOMATION_LIB_PATH/common_lib.sh
+
+req_env_vars CIRRUS_CI CIRRUS_CHANGE_IN_REPO
+
+# Architectures to test with (golang standard names)
+TESTARCHES="amd64 arm64"
+# containers_build_push.sh is sensitive to this value
+ARCHES=$(tr " " ","<<<"$TESTARCHES")
+export ARCHES
+# Contrived "version" for testing purposes
+FAKE_VER_X=$RANDOM
+FAKE_VER_Y=$RANDOM
+FAKE_VER_Z=$RANDOM
+FAKE_VERSION="$FAKE_VER_X.$FAKE_VER_Y.$FAKE_VER_Z"
+# Contrived source repository for testing
+SRC_TMP=$(mktemp -p '' -d tmp-build-push-test-XXXX)
+# Do not change, containers_build_push.sh is sensitive to the 'testing' name
+TEST_FQIN=example.com/testing/stable
+# Stable build should result in manifest list tagged this
+TEST_FQIN2=example.com/containers/testing
+# Don't allow containers_build_push.sh or tag_version.sh to auto-update at runtime
+export BUILDPUSHAUTOUPDATED=1
+
+trap "rm -rf $SRC_TMP" EXIT
+
+# containers_build_push.sh expects a git repository argument
+msg "
+##### Constructing local test repository #####"
+cd $SRC_TMP
+showrun git init -b main testing
+cd testing
+git config --local user.name "Testy McTestface"
+git config --local user.email "test@example.com"
+git config --local advice.detachedHead "false"
+git config --local commit.gpgsign "false"
+# The following paths match the style of sub-dir in the actual
+# skopeo/buildah/podman repositories.  Only the 'stable' flavor
+# is tested here, since it involves the most complex workflow.
+# Set a default flavor in the Containerfile to detect missing
+# flavor arg / envar processing.
+mkdir -vp "contrib/testimage/stable"
+cd "contrib/testimage/stable"
+echo "build-push-test version v$FAKE_VERSION" | tee "FAKE_VERSION"
+cat <<EOF | tee "Containerfile"
+FROM registry.fedoraproject.org/fedora:latest
+ARG FLAVOR="No Flavor Specified"
+ADD /FAKE_VERSION /
+RUN echo "FLAVOUR=\$FLAVOR" > /FLAVOUR
+EOF
+# As an additional test, build and check images when pasing
+# the 'stable' flavor name as a command-line arg instead
+# of using the subdirectory dirname (old method).
+cd $SRC_TMP/testing/contrib/testimage
+# This file is looked up by the build script.
+echo "Test Docs" > README.md
+cp stable/* ./
+cd $SRC_TMP/testing
+# The images will have the repo & commit ID set as labels
+git add --all
+git commit -m 'test repo initial commit'
+TEST_REVISION=$(git rev-parse HEAD)
+
+TEST_REPO_URL="file://$SRC_TMP/testing"
+
+# Given the flavor-name as the first argument, verify built image
+# expectations.  For 'stable' image, verify that containers_build_push.sh will properly
+# version-tagged both FQINs.  For other flavors, verify expected labels
+# on the `latest` tagged FQINs.
+verify_built_images() {
+    local _fqin _arch xy_ver x_ver img_ver img_src img_rev _fltr
+    local _test_tag expected_flavor _test_fqins img_docs
+    expected_flavor="$1"
+    msg "
+##### Testing execution of '$expected_flavor' images for arches $TESTARCHES #####"
+    podman --version
+    req_env_vars TESTARCHES FAKE_VERSION TEST_FQIN TEST_FQIN2
+
+    declare -a _test_fqins
+    _test_fqins=("${TEST_FQIN%stable}$expected_flavor")
+    if [[ "$expected_flavor" == "stable" ]]; then
+        _test_fqins+=("$TEST_FQIN2")
+        test_tag="v$FAKE_VERSION"
+        xy_ver="v$FAKE_VER_X.$FAKE_VER_Y"
+        x_ver="v$FAKE_VER_X"
+    else
+        test_tag="latest"
+        xy_ver="latest"
+        x_ver="latest"
+    fi
+
+    for _fqin in "${_test_fqins[@]}"; do
+        for _arch in $TESTARCHES; do
+            msg "Testing container can execute '/bin/true'"
+            showrun podman run -i --arch=$_arch --rm "$_fqin:$test_tag" /bin/true
+
+            msg "Testing container FLAVOR build-arg passed correctly"
+            showrun podman run -i --arch=$_arch --rm "$_fqin:$test_tag" \
+                cat /FLAVOUR | tee /dev/stderr | grep -Fxq "FLAVOUR=$expected_flavor"
+
+            if [[ "$expected_flavor" == "stable" ]]; then
+                msg "Testing tag '$xy_ver'"
+                if ! showrun podman manifest exists $_fqin:$xy_ver; then
+                    die "Failed to find manifest-list tagged '$xy_ver'"
+                fi
+
+                msg "Testing tag '$x_ver'"
+                if ! showrun podman manifest exists $_fqin:$x_ver; then
+                    die "Failed to find manifest-list tagged '$x_ver'"
+                fi
+            fi
+        done
+
+        if [[ "$expected_flavor" == "stable" ]]; then
+            msg "Testing image $_fqin:$test_tag version label"
+            _fltr='.[].Config.Labels."org.opencontainers.image.version"'
+            img_ver=$(podman inspect $_fqin:$test_tag | jq -r -e "$_fltr")
+            showrun test "$img_ver" == "v$FAKE_VERSION"
+        fi
+
+        msg "Testing image $_fqin:$test_tag source label"
+        _fltr='.[].Config.Labels."org.opencontainers.image.source"'
+        img_src=$(podman inspect $_fqin:$test_tag | jq -r -e "$_fltr")
+        showrun grep -F -q "$TEST_REPO_URL" <<<"$img_src"
+        showrun grep -F -q "$TEST_REVISION" <<<"$img_src"
+
+        msg "Testing image $_fqin:$test_tag revision label"
+        _fltr='.[].Config.Labels."org.opencontainers.image.revision"'
+        img_rev=$(podman inspect $_fqin:$test_tag | jq -r -e "$_fltr")
+        showrun test "$img_rev" == "$TEST_REVISION"
+
+        msg "Testing image $_fqin:$test_tag built.by.commit label"
+        _fltr='.[].Config.Labels."built.by.commit"'
+        img_bbc=$(podman inspect $_fqin:$test_tag | jq -r -e "$_fltr")
+        # Checked at beginning of script
+        # shellcheck disable=SC2154
+        showrun test "$img_bbc" == "$CIRRUS_CHANGE_IN_REPO"
+
+        msg "Testing image $_fqin:$test_tag docs label"
+        _fltr='.[].Config.Labels."org.opencontainers.image.documentation"'
+        img_docs=$(podman inspect $_fqin:$test_tag | jq -r -e "$_fltr")
+        showrun grep -F -q "README.md" <<<"$img_docs"
+    done
+}
+
+remove_built_images() {
+    buildah --version
+    for _fqin in $TEST_FQIN $TEST_FQIN2; do
+        for tag in latest v$FAKE_VERSION v$FAKE_VER_X.$FAKE_VER_Y v$FAKE_VER_X; do
+            # Don't care if this fails
+            podman manifest rm $_fqin:$tag || true
+        done
+    done
+}
+
+msg "
+##### Testing build-push subdir-flavor run of '$TEST_FQIN' & '$TEST_FQIN2' #####"
+cd $SRC_TMP/testing
+export DRYRUN=1  # Force containers_build_push.sh not to push anything
+req_env_vars ARCHES DRYRUN
+# containers_build_push.sh is sensitive to 'testing' value.
+# Also confirms containers_build_push.sh is on $PATH
+env A_DEBUG=1 containers_build_push.sh $TEST_REPO_URL contrib/testimage/stable
+verify_built_images stable
+
+msg "
+##### Testing build-push flavour-arg run for '$TEST_FQIN' & '$TEST_FQIN2' #####"
+remove_built_images
+env A_DEBUG=1 containers_build_push.sh $TEST_REPO_URL contrib/testimage foobarbaz
+verify_built_images foobarbaz
+
+msg "
+##### Testing build-push local repo run for '$TEST_FQIN'"
+env A_DEBUG=1 containers_build_push.sh .$TEST_REPO_URL contrib/testimage foobarbaz
+verify_built_images foobarbaz


### PR DESCRIPTION
Previously this script was obtained through a git clone before use. Separating it's definition and usage contexts makes maintenance, testing, and enhancement difficult.  Fix this by relocating the script and it's test here.