### PR TITLE
Fix podman use of remote git content

### DIFF
--- a/podman/stable/Containerfile
+++ b/podman/stable/Containerfile
@@ -25,9 +25,8 @@ RUN useradd podman; \
 echo -e "podman:1:999\npodman:1001:64535" > /etc/subuid; \
 echo -e "podman:1:999\npodman:1001:64535" > /etc/subgid;
 
-ARG _REPO_URL="https://raw.githubusercontent.com/containers/podman/main/contrib/podmanimage/stable"
-ADD $_REPO_URL/containers.conf /etc/containers/containers.conf
-ADD $_REPO_URL/podman-containers.conf /home/podman/.config/containers/containers.conf
+ADD /containers.conf /etc/containers/containers.conf
+ADD /podman-containers.conf /home/podman/.config/containers/containers.conf
 
 RUN mkdir -p /home/podman/.local/share/containers && \
     chown podman:podman -R /home/podman && \

--- a/podman/testing/Containerfile
+++ b/podman/testing/Containerfile
@@ -25,9 +25,8 @@ RUN useradd podman; \
 echo -e "podman:1:999\npodman:1001:64535" > /etc/subuid; \
 echo -e "podman:1:999\npodman:1001:64535" > /etc/subgid;
 
-ARG _REPO_URL="https://raw.githubusercontent.com/containers/podman/main/contrib/podmanimage/stable"
-ADD $_REPO_URL/containers.conf /etc/containers/containers.conf
-ADD $_REPO_URL/podman-containers.conf /home/podman/.config/containers/containers.conf
+ADD /containers.conf /etc/containers/containers.conf
+ADD /podman-containers.conf /home/podman/.config/containers/containers.conf
 
 RUN mkdir -p /home/podman/.local/share/containers && \
     chown podman:podman -R /home/podman

--- a/podman/testing/containers.conf
+++ b/podman/testing/containers.conf
@@ -1,0 +1,12 @@
+[containers]
+netns="host"
+userns="host"
+ipcns="host"
+utsns="host"
+cgroupns="host"
+cgroups="disabled"
+log_driver = "k8s-file"
+[engine]
+cgroup_manager = "cgroupfs"
+events_logger="file"
+runtime="crun"

--- a/podman/testing/podman-containers.conf
+++ b/podman/testing/podman-containers.conf
@@ -1,0 +1,5 @@
+[containers]
+volumes = [
+	"/proc:/proc",
+]
+default_sysctls = []

--- a/podman/upstream/Containerfile
+++ b/podman/upstream/Containerfile
@@ -31,9 +31,8 @@ RUN useradd podman; \
 echo -e "podman:1:999\npodman:1001:64535" > /etc/subuid; \
 echo -e "podman:1:999\npodman:1001:64535" > /etc/subgid;
 
-ARG _REPO_URL="https://raw.githubusercontent.com/containers/podman/main/contrib/podmanimage/stable"
-ADD $_REPO_URL/containers.conf /etc/containers/containers.conf
-ADD $_REPO_URL/podman-containers.conf /home/podman/.config/containers/containers.conf
+ADD /containers.conf /etc/containers/containers.conf
+ADD /podman-containers.conf /home/podman/.config/containers/containers.conf
 
 RUN mkdir -p /home/podman/.local/share/containers && \
     chown podman:podman -R /home/podman && \

--- a/podman/upstream/containers.conf
+++ b/podman/upstream/containers.conf
@@ -1,0 +1,12 @@
+[containers]
+netns="host"
+userns="host"
+ipcns="host"
+utsns="host"
+cgroupns="host"
+cgroups="disabled"
+log_driver = "k8s-file"
+[engine]
+cgroup_manager = "cgroupfs"
+events_logger="file"
+runtime="crun"

--- a/podman/upstream/podman-containers.conf
+++ b/podman/upstream/podman-containers.conf
@@ -1,0 +1,5 @@
+[containers]
+volumes = [
+	"/proc:/proc",
+]
+default_sysctls = []


### PR DESCRIPTION
Container context directories should be self-contained, but the various podman flavors were not.  All of them referred to a file on github that no longer exists.  For now, duplicate the necessary files and add them directly.  A future commit may de-duplicate the three flavors (stable/testing/upstream) into a single Containerfile (similar to how it's done in buildah).