### PR TITLE
fix: Also use `storage.conf` when running `rootless` with user `podman`

### DIFF
--- a/podman/Containerfile
+++ b/podman/Containerfile
@@ -78,8 +78,10 @@ RUN sed -e 's|^#mount_program|mount_program|g' \
            -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
            /usr/share/containers/storage.conf \
            > /etc/containers/storage.conf && \
-           cp /etc/containers/storage.conf /home/podman/.config/containers/storage.conf && \
-           chown 1000:1000 /home/podman/.config/containers/storage.conf
+    sed -e 's|^graphroot|#graphroot|g' \
+        -e 's|^runroot|#runroot|g' \
+           /etc/containers/storage.conf >/home/podman/.config/containers/storage.conf && \
+    chown 1000:1000 /home/podman/.config/containers/storage.conf
 
 # Setup internal Podman to pass subscriptions down from host to internal container
 RUN printf '/run/secrets/etc-pki-entitlement:/run/secrets/etc-pki-entitlement\n/run/secrets/rhsm:/run/secrets/rhsm\n' > /etc/containers/mounts.conf

--- a/podman/Containerfile
+++ b/podman/Containerfile
@@ -77,7 +77,9 @@ RUN sed -e 's|^#mount_program|mount_program|g' \
            -e '/additionalimage.*/a "/var/lib/shared",' \
            -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
            /usr/share/containers/storage.conf \
-           > /etc/containers/storage.conf
+           > /etc/containers/storage.conf && \
+           cp /etc/containers/storage.conf /home/podman/.config/containers/storage.conf && \
+           chown 1000:1000 /home/podman/.config/containers/storage.conf
 
 # Setup internal Podman to pass subscriptions down from host to internal container
 RUN printf '/run/secrets/etc-pki-entitlement:/run/secrets/etc-pki-entitlement\n/run/secrets/rhsm:/run/secrets/rhsm\n' > /etc/containers/mounts.conf


### PR DESCRIPTION
The `storage.conf` is not added to the `/home/podman/.config/containers/storage.conf` which is a bit odd.

Not sure if that is by design, but generally why should the `podman` user not have the same setting?
The `graphroot` should probably change so I outcommented it together with `runroot` which makes them the  
default directory `podman` chooses when runnint rootless.


