### PR TITLE
Bump up CI/CD VM image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ env:
     CIRRUS_SHELL: "/bin/bash"
     # No need to go crazy, but grab enough to cover most PRs
     CIRRUS_CLONE_DEPTH: 10
-    IMAGE_SUFFIX: "c20240410t200635z-f39f38d13"
+    IMAGE_SUFFIX: "c20240424t143933z-f39f38d13"
 
 gcp_credentials: ENCRYPTED[88b219cf6b4f2d70c4ff7f8c6c3186396102e14a27b47b985e40a0a0bc5337a270f9eee195b36ff6b3e2f07558998a95]
 


### PR DESCRIPTION
Specifically, this image includes fixes for the 'immutable' image build:

```
Error retrieving set of manifest-list tags to push for...
```

Ref: https://github.com/containers/automation_images/pull/348