### PR TITLE
Simplify immutable image tagging

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,9 +72,6 @@ test_image_build_task:
         - env:
               FLAVOR_NAME: stable
           matrix: *pbs_images
-        - env:
-              FLAVOR_NAME: immutable
-          matrix: *pbs_images
     script: &pbs_script |
         source /etc/automation_environment
         ./ci/containers_build_push.sh ${CIRRUS_REPO_CLONE_URL} ${CTX_SUB} ${FLAVOR_NAME}

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ or `skopeo`:
     `vX.Y`, and `vX.Y.Z`) the image contents will be updated daily to incorporate
     (especially) security updates.
   * `quay.io/containers/*:<version>-immutable` -  Uses the same source as the 'stable'
-    images, is built daily, but version-tags are never overwritten once pushed.  This is
-    intended for users that value an unchanging image tag and digest over having daily
-    security updates.  All three `<version>` values are available, `vX-immutable`,
+    images, built daily, but version-tags are never overwritten once pushed.  Tags
+    will only be removed in case of an extreme security problem.  Otherwise, these
+    images are intended for users that value an unchanging image tag and digest over
+    daily security updates.  All three `<version>` values are available, `vX-immutable`,
     `vX.Y-immutable` and `vX.Y.Z-immutable`.
   * `quay.io/containers/*:latest` and `quay.io/*/stable:latest` -
     Built daily using the same `Containerfile` as above.  The tool versions


### PR DESCRIPTION
Previously immutable tagged images were separately built as a pseudo- flavor, with the actual build-time flavor being reset to 'stable'.  This is overly complex and unnecessary since the 'stable' flavor build may simply be reused.  Alter the build and tagging automation to handle the `-immutable` tags automatically for every 'stable' flavor image.  In other words, any necessary `-immutable` tags will simply be added by `tag_version.sh` when operating on the 'stable' flavor images.

Minor: Also update immutable image docs.