### PR TITLE
Fix not skipping builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -59,13 +59,13 @@ test_image_build_task:
           matrix: &pbs_images
                 - env:
                       CTX_SUB: podman
-                      skip: "!changesInclude('.cirrus.yml', 'ci/containers_build_push.sh', 'ci/tag_version.sh', 'podman/**/*')"
+                  skip: "!changesInclude('.cirrus.yml', 'ci/containers_build_push.sh', 'ci/tag_version.sh', 'podman/**/*')"
                 - env:
                       CTX_SUB: buildah
-                      skip: "!changesInclude('.cirrus.yml', 'ci/containers_build_push.sh', 'ci/tag_version.sh', 'buildah/**/*')"
+                  skip: "!changesInclude('.cirrus.yml', 'ci/containers_build_push.sh', 'ci/tag_version.sh', 'buildah/**/*')"
                 - env:
                       CTX_SUB: skopeo
-                      skip: "!changesInclude('.cirrus.yml', 'ci/containers_build_push.sh', 'ci/tag_version.sh', 'skopeo/**/*')"
+                  skip: "!changesInclude('.cirrus.yml', 'ci/containers_build_push.sh', 'ci/tag_version.sh', 'skopeo/**/*')"
         - env:
               FLAVOR_NAME: testing
           matrix: *pbs_images


### PR DESCRIPTION
It's intended that certain test builds may be skipped based on the files that change in a PR.  Unfortunately the attribute was over-indented so Cirrus-CI interprets it as an env. var instead of a task attribute.  Fix this.