### PR TITLE
Fix cron task skipping builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -59,13 +59,28 @@ test_image_build_task:
           matrix: &pbs_images
                 - env:
                       CTX_SUB: podman
-                  skip: "!changesInclude('.cirrus.yml', 'ci/containers_build_push.sh', 'ci/tag_version.sh', 'podman/**/*')"
+                  # N/B: The following skip conditions also apply to the
+                  # cron_image_build task via the pbs_images alias.  Build
+                  # skipping is desirable only for PRs, never for Cirrus-cron.
+                  skip: |
+                      $CIRRUS_PR != '' &&
+                      !changesInclude('.cirrus.yml',
+                                      'ci/containers_build_push.sh', 'ci/tag_version.sh',
+                                      'podman/**/*')
                 - env:
                       CTX_SUB: buildah
-                  skip: "!changesInclude('.cirrus.yml', 'ci/containers_build_push.sh', 'ci/tag_version.sh', 'buildah/**/*')"
+                  skip: |
+                      $CIRRUS_PR != '' &&
+                      !changesInclude('.cirrus.yml',
+                                      'ci/containers_build_push.sh', 'ci/tag_version.sh',
+                                      'buildah/**/*')
                 - env:
                       CTX_SUB: skopeo
-                  skip: "!changesInclude('.cirrus.yml', 'ci/containers_build_push.sh', 'ci/tag_version.sh', 'skopeo/**/*')"
+                  skip: |
+                      $CIRRUS_PR != '' &&
+                      !changesInclude('.cirrus.yml',
+                                      'ci/containers_build_push.sh', 'ci/tag_version.sh',
+                                      'skopeo/**/*')
         - env:
               FLAVOR_NAME: testing
           matrix: *pbs_images


### PR DESCRIPTION
Previously, it was possible for the cron task to skip all builds given the changed-file condition would always evaluate `True`.  Fix this by also requiring the matrix element's skip to also require running in a PR context.  Also add a comment warning future maintainers about the re-use of the skip's via the `pbs_images` YAML anchor/alias.

Fixes https://github.com/containers/podman/issues/22861

Also ref. https://github.com/containers/image/issues/2203#issuecomment-2142072150