### PR TITLE
Podman/Buildah: Add uCPP package via new build-arg

### DIFF
--- a/buildah/Containerfile
+++ b/buildah/Containerfile
@@ -31,6 +31,8 @@ label "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BI
 RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
     echo -e "minrate=100\ntimeout=60\n" >> /etc/dnf/dnf.conf
 
+ARG INSTALL_RPMS="buildah fuse-overlayfs ucpp"
+
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking
 # up space.
@@ -42,16 +44,16 @@ RUN dnf -y makecache && \
     rpm --setcaps shadow-utils 2>/dev/null && \
     case "${FLAVOR}" in \
       stable) \
-        dnf -y install buildah fuse-overlayfs cpp --exclude container-selinux \
+        dnf -y install $INSTALL_RPMS --exclude container-selinux \
       ;; \
       testing) \
-        dnf -y install --enablerepo=updates-testing buildah fuse-overlayfs cpp \
-            --exclude container-selinux \
+        dnf -y install $INSTALL_RPMS --exclude container-selinux \
+            --enablerepo=updates-testing \
       ;; \
       upstream) \
         dnf -y install 'dnf-command(copr)' --enablerepo=updates-testing && \
         dnf -y copr enable rhcontainerbot/podman-next && \
-        dnf -y install buildah fuse-overlayfs \
+        dnf -y install $INSTALL_RPMS \
             --exclude container-selinux \
             --enablerepo=updates-testing  \
       ;; \
@@ -60,6 +62,7 @@ RUN dnf -y makecache && \
         exit 1 \
       ;; \
     esac && \
+    ln -s /usr/bin/ucpp /usr/local/bin/cpp && \
     dnf -y clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 

--- a/podman/Containerfile
+++ b/podman/Containerfile
@@ -28,6 +28,8 @@ ARG FLAVOR=stable
 RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
     echo -e "minrate=100\ntimeout=60\n" >> /etc/dnf/dnf.conf
 
+ARG INSTALL_RPMS="podman fuse-overlayfs openssh-clients ucpp"
+
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking
 # up space.
@@ -39,16 +41,16 @@ RUN dnf -y makecache && \
     rpm --setcaps shadow-utils 2>/dev/null && \
     case "${FLAVOR}" in \
       stable) \
-        dnf -y install podman fuse-overlayfs openssh-clients --exclude container-selinux \
+        dnf -y install $INSTALL_RPMS --exclude container-selinux \
       ;; \
       testing) \
-        dnf -y install podman fuse-overlayfs openssh-clients --exclude container-selinux \
+        dnf -y install $INSTALL_RPMS --exclude container-selinux \
             --enablerepo updates-testing \
       ;; \
       upstream) \
         dnf -y install 'dnf-command(copr)' --enablerepo=updates-testing && \
         dnf -y copr enable rhcontainerbot/podman-next && \
-        dnf -y install podman fuse-overlayfs openssh-clients \
+        dnf -y install $INSTALL_RPMS \
             --exclude container-selinux \
             --enablerepo=updates-testing \
       ;; \
@@ -57,12 +59,13 @@ RUN dnf -y makecache && \
         exit 1 \
       ;; \
     esac && \
+    ln -s /usr/bin/ucpp /usr/local/bin/cpp && \
     dnf clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
-RUN useradd podman; \
-echo -e "podman:1:999\npodman:1001:64535" > /etc/subuid; \
-echo -e "podman:1:999\npodman:1001:64535" > /etc/subgid;
+RUN useradd podman && \
+    echo -e "podman:1:999\npodman:1001:64535" > /etc/subuid && \
+    echo -e "podman:1:999\npodman:1001:64535" > /etc/subgid
 
 ADD /containers.conf /etc/containers/containers.conf
 ADD /podman-containers.conf /home/podman/.config/containers/containers.conf


### PR DESCRIPTION
Fixes #35 

Since podman supports use of a `#include` directive in `Containerfile`
it's prudent to include the tooling necessary to fully make use of this
feature.  Add a symlink from `cpp` -> `ucpp` as there isn't one by
default.

Also, since downstream users of the podman image may want a
way to more easily customize the package list, de-duplicate
the specification via a new build-arg.