### PR TITLE
Fix build-skip logic

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -66,21 +66,21 @@ test_image_build_task:
                       $CIRRUS_PR != '' &&
                       !changesInclude('.cirrus.yml',
                                       'ci/containers_build_push.sh', 'ci/tag_version.sh',
-                                      'podman/**/*')
+                                      'podman/*')
                 - env:
                       CTX_SUB: buildah
                   skip: |
                       $CIRRUS_PR != '' &&
                       !changesInclude('.cirrus.yml',
                                       'ci/containers_build_push.sh', 'ci/tag_version.sh',
-                                      'buildah/**/*')
+                                      'buildah/*')
                 - env:
                       CTX_SUB: skopeo
                   skip: |
                       $CIRRUS_PR != '' &&
                       !changesInclude('.cirrus.yml',
                                       'ci/containers_build_push.sh', 'ci/tag_version.sh',
-                                      'skopeo/**/*')
+                                      'skopeo/*')
         - env:
               FLAVOR_NAME: testing
           matrix: *pbs_images


### PR DESCRIPTION
For whatever reason the `path/**/*` wildcard is not matching a change to a `path/Containerfile`.  Since there are no subdirectories under the container context dirs, remove the `**` part.