### PR TITLE
Install git-core, use real cpp, add subid mappings for root

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -118,7 +118,7 @@ test_aio_image_build_task:
     alias: test_aio_image_build
     name: "Test build AIO image"
     only_if: *is_pr
-    skip: "!changesInclude('.cirrus.yml', 'ci/aio_build_push.sh', 'ci/tag_version.sh', 'aio/**/*')"
+    skip: "!changesInclude('.cirrus.yml', 'ci/aio_build_push.sh', 'ci/tag_version.sh', 'aio/*')"
     depends_on:
         - test_build-push
     gce_instance: *build_push

--- a/aio/Containerfile
+++ b/aio/Containerfile
@@ -18,9 +18,11 @@ FROM registry.fedoraproject.org/fedora-minimal:latest
 RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
     echo -e "minrate=100\ntimeout=60\n" >> /etc/dnf/dnf.conf
 
+ARG INSTALL_RPMS="podman buildah skopeo fuse-overlayfs openssh-clients"
+
 RUN microdnf -y makecache && \
     microdnf -y update && \
-    microdnf -y install podman buildah skopeo fuse-overlayfs openssh-clients \
+    microdnf -y install $INSTALL_RPMS \
         --exclude "container-selinux,qemu-*" && \
     rpm --setcaps shadow-utils 2>/dev/null && \
     microdnf clean all && \

--- a/aio/Containerfile
+++ b/aio/Containerfile
@@ -18,7 +18,7 @@ FROM registry.fedoraproject.org/fedora-minimal:latest
 RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
     echo -e "minrate=100\ntimeout=60\n" >> /etc/dnf/dnf.conf
 
-ARG INSTALL_RPMS="podman buildah skopeo fuse-overlayfs openssh-clients"
+ARG INSTALL_RPMS="podman buildah skopeo fuse-overlayfs openssh-clients git-core"
 
 RUN microdnf -y makecache && \
     microdnf -y update && \

--- a/aio/Containerfile
+++ b/aio/Containerfile
@@ -18,7 +18,7 @@ FROM registry.fedoraproject.org/fedora-minimal:latest
 RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
     echo -e "minrate=100\ntimeout=60\n" >> /etc/dnf/dnf.conf
 
-ARG INSTALL_RPMS="podman buildah skopeo fuse-overlayfs openssh-clients git-core"
+ARG INSTALL_RPMS="podman buildah skopeo fuse-overlayfs openssh-clients cpp git-core"
 
 RUN microdnf -y makecache && \
     microdnf -y update && \

--- a/aio/Containerfile
+++ b/aio/Containerfile
@@ -30,8 +30,8 @@ RUN microdnf -y makecache && \
 
 # It's assumed `user` will end up with UID/GID 1000
 RUN useradd user && \
-    echo -e "user:1:999\nuser:1001:64535" > /etc/subuid && \
-    echo -e "user:1:999\nuser:1001:64535" > /etc/subgid
+    echo -e "root:1:65535\nuser:1:999\nuser:1001:64535" > /etc/subuid && \
+    echo -e "root:1:65535\nuser:1:999\nuser:1001:64535" > /etc/subgid
 
 ADD /containers.conf /etc/containers/containers.conf
 ADD /user-containers.conf /home/user/.config/containers/containers.conf

--- a/buildah/Containerfile
+++ b/buildah/Containerfile
@@ -90,9 +90,10 @@ RUN mkdir -p /var/lib/shared/overlay-images \
     touch /var/lib/shared/vfs-layers/layers.lock
 
 # Define uid/gid ranges for our user https://github.com/containers/buildah/issues/3053
+# It's assumed `build` will end up with UID/GID 1000
 RUN useradd build && \
-    echo -e "build:1:999\nbuild:1001:64535" > /etc/subuid && \
-    echo -e "build:1:999\nbuild:1001:64535" > /etc/subgid && \
+    echo -e "root:1:65535\nbuild:1:999\nbuild:1001:64535" > /etc/subuid && \
+    echo -e "root:1:65535\nbuild:1:999\nbuild:1001:64535" > /etc/subgid && \
     mkdir -p /home/build/.local/share/containers && \
     mkdir -p /home/build/.config/containers && \
     chown -R build:build /home/build

--- a/buildah/Containerfile
+++ b/buildah/Containerfile
@@ -31,7 +31,7 @@ label "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BI
 RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
     echo -e "minrate=100\ntimeout=60\n" >> /etc/dnf/dnf.conf
 
-ARG INSTALL_RPMS="buildah fuse-overlayfs ucpp"
+ARG INSTALL_RPMS="buildah fuse-overlayfs ucpp git-core"
 
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking

--- a/buildah/Containerfile
+++ b/buildah/Containerfile
@@ -31,7 +31,7 @@ label "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BI
 RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
     echo -e "minrate=100\ntimeout=60\n" >> /etc/dnf/dnf.conf
 
-ARG INSTALL_RPMS="buildah fuse-overlayfs ucpp git-core"
+ARG INSTALL_RPMS="buildah fuse-overlayfs cpp git-core"
 
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking
@@ -62,7 +62,6 @@ RUN dnf -y makecache && \
         exit 1 \
       ;; \
     esac && \
-    ln -s /usr/bin/ucpp /usr/local/bin/cpp && \
     dnf -y clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 

--- a/podman/Containerfile
+++ b/podman/Containerfile
@@ -28,7 +28,7 @@ ARG FLAVOR=stable
 RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
     echo -e "minrate=100\ntimeout=60\n" >> /etc/dnf/dnf.conf
 
-ARG INSTALL_RPMS="podman fuse-overlayfs openssh-clients ucpp"
+ARG INSTALL_RPMS="podman fuse-overlayfs openssh-clients ucpp git-core"
 
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking

--- a/podman/Containerfile
+++ b/podman/Containerfile
@@ -62,9 +62,10 @@ RUN dnf -y makecache && \
     dnf clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
+# It's assumed `podman` will end up with UID/GID 1000
 RUN useradd podman && \
-    echo -e "podman:1:999\npodman:1001:64535" > /etc/subuid && \
-    echo -e "podman:1:999\npodman:1001:64535" > /etc/subgid
+    echo -e "root:1:65535\npodman:1:999\npodman:1001:64535" > /etc/subuid && \
+    echo -e "root:1:65535\npodman:1:999\npodman:1001:64535" > /etc/subgid
 
 ADD /containers.conf /etc/containers/containers.conf
 ADD /podman-containers.conf /home/podman/.config/containers/containers.conf

--- a/podman/Containerfile
+++ b/podman/Containerfile
@@ -28,7 +28,7 @@ ARG FLAVOR=stable
 RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
     echo -e "minrate=100\ntimeout=60\n" >> /etc/dnf/dnf.conf
 
-ARG INSTALL_RPMS="podman fuse-overlayfs openssh-clients ucpp git-core"
+ARG INSTALL_RPMS="podman fuse-overlayfs openssh-clients cpp git-core"
 
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking
@@ -59,7 +59,6 @@ RUN dnf -y makecache && \
         exit 1 \
       ;; \
     esac && \
-    ln -s /usr/bin/ucpp /usr/local/bin/cpp && \
     dnf clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 

--- a/skopeo/Containerfile
+++ b/skopeo/Containerfile
@@ -61,9 +61,10 @@ RUN dnf -y update && \
     dnf clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
+# It's assumed `skopeo` will end up with UID/GID 1000
 RUN useradd skopeo && \
-    echo skopeo:100000:65536 > /etc/subuid && \
-    echo skopeo:100000:65536 > /etc/subgid
+    echo -e "root:1:65535\nskopeo:1:999\nskopeo:1001:64535" > /etc/subuid && \
+    echo -e "root:1:65535\nskopeo:1:999\nskopeo:1001:64535" > /etc/subgid
 
 # Copy & modify the defaults to provide reference if runtime changes needed.
 # Changes here are required for running with fuse-overlay storage inside container.

--- a/skopeo/Containerfile
+++ b/skopeo/Containerfile
@@ -28,6 +28,8 @@ ARG FLAVOR=stable
 RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
     echo -e "minrate=100\ntimeout=60\n" >> /etc/dnf/dnf.conf
 
+ARG INSTALL_RPMS="skopeo fuse-overlayfs"
+
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking
 # up space.
@@ -38,16 +40,16 @@ RUN dnf -y update && \
     rpm --setcaps shadow-utils 2>/dev/null && \
     case "${FLAVOR}" in \
       stable) \
-        dnf -y install skopeo fuse-overlayfs --exclude container-selinux \
+        dnf -y install $INSTALL_RPMS --exclude container-selinux \
       ;; \
       testing) \
-        dnf -y install skopeo fuse-overlayfs --exclude container-selinux \
+        dnf -y install $INSTALL_RPMS --exclude container-selinux \
             --enablerepo updates-testing \
       ;; \
       upstream) \
         dnf -y install 'dnf-command(copr)' --enablerepo=updates-testing && \
         dnf -y copr enable rhcontainerbot/podman-next && \
-        dnf -y install skopeo fuse-overlayfs \
+        dnf -y install $INSTALL_RPMS \
             --exclude container-selinux \
             --enablerepo=updates-testing \
       ;; \


### PR DESCRIPTION
* In the "aio" and "skopeo" image Containerfiles, use an "INSTALL_RPMS" build argument to hold the names of packages that will be installed, allowing it to optionally be overridden at build-time.
* Install git-core in the "buildah", "podman", and "aio" images, fixing #49.
* Install regular cpp instead of ucpp in the "buildah", "podman", and "aio" images, fixing #42.
* Add subid mappings for "root" in all images, fixing #46.
* Set the subid mappings for the "skopeo" user in the "skopeo" image to the same "1:999"+"1001:64535" ranges used for the unprivileged users the other images create, as I'm not aware of the intention behind it being different from the other three images.