### PR TITLE
Make SOURCE_DATE_EPOCH available for builds

### DIFF
--- a/aio/Containerfile
+++ b/aio/Containerfile
@@ -11,6 +11,8 @@
 
 FROM registry.fedoraproject.org/fedora-minimal:latest
 
+ARG SOURCE_DATE_EPOCH
+
 # When building for multiple-architectures in parallel using emulation
 # it's really easy for one/more dnf processes to timeout or mis-count
 # the minimum download rates.  Bump both to be extremely forgiving of
@@ -18,7 +20,7 @@ FROM registry.fedoraproject.org/fedora-minimal:latest
 RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
     echo -e "minrate=100\ntimeout=60\n" >> /etc/dnf/dnf.conf
 
-ARG INSTALL_RPMS="podman buildah skopeo fuse-overlayfs openssh-clients cpp git-core"
+ARG INSTALL_RPMS="podman buildah skopeo fuse-overlayfs openssh-clients cpp git-core ${SOURCE_DATE_EPOCH:+sqlite}"
 
 RUN microdnf -y makecache && \
     microdnf -y update && \
@@ -26,6 +28,10 @@ RUN microdnf -y makecache && \
         --exclude "container-selinux,qemu-*" && \
     rpm --setcaps shadow-utils 2>/dev/null && \
     microdnf clean all && \
+    if test -n "$SOURCE_DATE_EPOCH" ; then \
+        sqlite3 /usr/lib/sysimage/libdnf5/transaction_history.sqlite "UPDATE trans SET dt_begin=$SOURCE_DATE_EPOCH, dt_end=$SOURCE_DATE_EPOCH; PRAGMA journal_mode=DELETE; PRAGMA journal_mode=WAL" ; \
+    fi && \
+    rm -fv /etc/machine-id /var/lib/systemd/random-seed /var/lib/dnf/repos/*/countme && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # It's assumed `user` will end up with UID/GID 1000

--- a/buildah/Containerfile
+++ b/buildah/Containerfile
@@ -20,9 +20,12 @@
 #
 
 FROM registry.fedoraproject.org/fedora:latest
+
+ARG SOURCE_DATE_EPOCH
+
 ARG FLAVOR=stable
 
-label "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,SYS_CHROOT"
+LABEL "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,SYS_CHROOT"
 
 # When building for multiple-architectures in parallel using emulation
 # it's really easy for one/more dnf processes to timeout or mis-count
@@ -31,7 +34,7 @@ label "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BI
 RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
     echo -e "minrate=100\ntimeout=60\n" >> /etc/dnf/dnf.conf
 
-ARG INSTALL_RPMS="buildah fuse-overlayfs cpp git-core"
+ARG INSTALL_RPMS="buildah fuse-overlayfs cpp git-core ${SOURCE_DATE_EPOCH:+sqlite}"
 
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking
@@ -63,7 +66,12 @@ RUN dnf -y makecache && \
       ;; \
     esac && \
     dnf -y clean all && \
-    rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+    if test -n "$SOURCE_DATE_EPOCH" ; then \
+        sqlite3 /usr/lib/sysimage/libdnf5/transaction_history.sqlite "UPDATE trans SET dt_begin=$SOURCE_DATE_EPOCH, dt_end=$SOURCE_DATE_EPOCH; PRAGMA journal_mode=DELETE; PRAGMA journal_mode=WAL" ; \
+    fi && \
+    rm -fv /etc/machine-id /var/lib/systemd/random-seed /var/lib/dnf/repos/*/countme && \
+    rm -rf /var/cache/*/* /var/log/dnf* /var/log/hawkey.log /var/log/yum.*
+
 
 ADD ./containers.conf /etc/containers/
 

--- a/podman/Containerfile
+++ b/podman/Containerfile
@@ -19,6 +19,9 @@
 # https://bodhi.fedoraproject.org/updates/?search=podman
 
 FROM registry.fedoraproject.org/fedora:latest
+
+ARG SOURCE_DATE_EPOCH
+
 ARG FLAVOR=stable
 
 # When building for multiple-architectures in parallel using emulation
@@ -28,7 +31,7 @@ ARG FLAVOR=stable
 RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
     echo -e "minrate=100\ntimeout=60\n" >> /etc/dnf/dnf.conf
 
-ARG INSTALL_RPMS="podman fuse-overlayfs openssh-clients cpp git-core"
+ARG INSTALL_RPMS="podman fuse-overlayfs openssh-clients cpp git-core ${SOURCE_DATE_EPOCH:+sqlite}"
 
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking
@@ -60,7 +63,11 @@ RUN dnf -y makecache && \
       ;; \
     esac && \
     dnf clean all && \
-    rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+    if test -n "$SOURCE_DATE_EPOCH" ; then \
+        sqlite3 /usr/lib/sysimage/libdnf5/transaction_history.sqlite "UPDATE trans SET dt_begin=$SOURCE_DATE_EPOCH, dt_end=$SOURCE_DATE_EPOCH; PRAGMA journal_mode=DELETE; PRAGMA journal_mode=WAL" ; \
+    fi && \
+    rm -fv /etc/machine-id /var/lib/systemd/random-seed /var/lib/dnf/repos/*/countme && \
+    rm -rf /var/cache /var/log/dnf* /var/log/hawkey.log /var/log/yum.*
 
 # It's assumed `podman` will end up with UID/GID 1000
 RUN useradd podman && \

--- a/skopeo/Containerfile
+++ b/skopeo/Containerfile
@@ -19,6 +19,9 @@
 # https://bodhi.fedoraproject.org/updates/?search=skopeo
 
 FROM registry.fedoraproject.org/fedora:latest
+
+ARG SOURCE_DATE_EPOCH
+
 ARG FLAVOR=stable
 
 # When building for multiple-architectures in parallel using emulation
@@ -28,7 +31,7 @@ ARG FLAVOR=stable
 RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
     echo -e "minrate=100\ntimeout=60\n" >> /etc/dnf/dnf.conf
 
-ARG INSTALL_RPMS="skopeo fuse-overlayfs"
+ARG INSTALL_RPMS="skopeo fuse-overlayfs ${SOURCE_DATE_EPOCH:+sqlite}"
 
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking
@@ -59,6 +62,10 @@ RUN dnf -y update && \
       ;; \
     esac && \
     dnf clean all && \
+    if test -n "$SOURCE_DATE_EPOCH" ; then \
+        sqlite3 /usr/lib/sysimage/libdnf5/transaction_history.sqlite "UPDATE trans SET dt_begin=$SOURCE_DATE_EPOCH, dt_end=$SOURCE_DATE_EPOCH; PRAGMA journal_mode=DELETE; PRAGMA journal_mode=WAL" ; \
+    fi && \
+    rm -fv /etc/machine-id /var/lib/systemd/random-seed /var/lib/dnf/repos/*/countme && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # It's assumed `skopeo` will end up with UID/GID 1000


### PR DESCRIPTION
If we're passed a SOURCE_DATE_EPOCH build arg, declare it so that it gets passed to rpm, and use it to rewrite the dates in the dnf transaction database before flushing its write-ahead journal by deleting and restarting it.

Remove hawkey logs, "countme" files, and the generated machine-id and rng seed.