### PR TITLE
Remove /usr/lib/systemd/profile.d/*, too

### DIFF
--- a/aio/Containerfile
+++ b/aio/Containerfile
@@ -32,6 +32,7 @@ RUN microdnf -y makecache && \
         sqlite3 /usr/lib/sysimage/libdnf5/transaction_history.sqlite "UPDATE trans SET dt_begin=$SOURCE_DATE_EPOCH, dt_end=$SOURCE_DATE_EPOCH; PRAGMA journal_mode=DELETE; PRAGMA journal_mode=WAL" ; \
     fi && \
     rm -fv /etc/machine-id /var/lib/systemd/random-seed /var/lib/dnf/repos/*/countme && \
+    rm -fv /usr/lib/systemd/profile.d/* && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # It's assumed `user` will end up with UID/GID 1000

--- a/buildah/Containerfile
+++ b/buildah/Containerfile
@@ -70,6 +70,7 @@ RUN dnf -y makecache && \
         sqlite3 /usr/lib/sysimage/libdnf5/transaction_history.sqlite "UPDATE trans SET dt_begin=$SOURCE_DATE_EPOCH, dt_end=$SOURCE_DATE_EPOCH; PRAGMA journal_mode=DELETE; PRAGMA journal_mode=WAL" ; \
     fi && \
     rm -fv /etc/machine-id /var/lib/systemd/random-seed /var/lib/dnf/repos/*/countme && \
+    rm -fv /usr/lib/systemd/profile.d/* && \
     rm -rf /var/cache/*/* /var/log/dnf* /var/log/hawkey.log /var/log/yum.*
 
 

--- a/podman/Containerfile
+++ b/podman/Containerfile
@@ -67,6 +67,7 @@ RUN dnf -y makecache && \
         sqlite3 /usr/lib/sysimage/libdnf5/transaction_history.sqlite "UPDATE trans SET dt_begin=$SOURCE_DATE_EPOCH, dt_end=$SOURCE_DATE_EPOCH; PRAGMA journal_mode=DELETE; PRAGMA journal_mode=WAL" ; \
     fi && \
     rm -fv /etc/machine-id /var/lib/systemd/random-seed /var/lib/dnf/repos/*/countme && \
+    rm -fv /usr/lib/systemd/profile.d/* && \
     rm -rf /var/cache /var/log/dnf* /var/log/hawkey.log /var/log/yum.*
 
 # It's assumed `podman` will end up with UID/GID 1000

--- a/skopeo/Containerfile
+++ b/skopeo/Containerfile
@@ -66,6 +66,7 @@ RUN dnf -y update && \
         sqlite3 /usr/lib/sysimage/libdnf5/transaction_history.sqlite "UPDATE trans SET dt_begin=$SOURCE_DATE_EPOCH, dt_end=$SOURCE_DATE_EPOCH; PRAGMA journal_mode=DELETE; PRAGMA journal_mode=WAL" ; \
     fi && \
     rm -fv /etc/machine-id /var/lib/systemd/random-seed /var/lib/dnf/repos/*/countme && \
+    rm -fv /usr/lib/systemd/profile.d/* && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # It's assumed `skopeo` will end up with UID/GID 1000


### PR DESCRIPTION
Remove /usr/lib/systemd/profile.d/*, since one of those scriptlets (80-systemd-osc-context.sh) outputs an error (`bash: /etc/machine-id: No such file or directory`) with every shell prompt because we removed /etc/machine-id, and the scriptlet just assumes it's there.