### PR TITLE
Move this repository into Podman Container Tools

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,4 +1,3 @@
-## Monorepo menagerie of images build automation project Code of Conduct
+## The Podman Project Community Code of Conduct
 
-Monorepo menagerie of images build automation project follows the
-[Containers Community Code of Conduct](https://github.com/containers/common/blob/main/CODE-OF-CONDUCT.md).
+The Podman project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,24 @@
+# Image Build Maintainers
+
+[GOVERNANCE.md](https://github.com/containers/podman/blob/main/GOVERNANCE.md)
+describes the Podman project's governance and the Project Roles used below.
+
+Please note that this file only includes the Image Build subproject's Maintainers and Reviewers.
+Maintainers and Reviewers for the other subprojects are found in their respective repository's MAINTAINERS.md files.
+
+## Maintainers
+
+Core Maintainers and Community Managers can be found in the main maintainers list [here](https://github.com/podman-container-tools/podman/blob/main/MAINTAINERS.md).
+This contains only the Reviewers and Maintainers unique to the Image Build subproject.
+
+| Maintainer        | GitHub ID                                                | Project Roles     | Affiliation                                  |
+|-------------------|----------------------------------------------------------|-------------------|----------------------------------------------|
+| Tim Zhou          | [timcoding1988](https://github.com/timcoding1988)        | Maintainer        | [Red Hat](https://github.com/RedHatOfficial) |
+
+## Alumni
+
+There are currently no alumni.
+
+## Credits
+
+The structure of this document was based off of the equivalent one in the [CRI-O Project](https://github.com/cri-o/cri-o/blob/main/MAINTAINERS.md).


### PR DESCRIPTION
This was discussed and agreed to in #57 on Github. Fortunately the maintainers of this repo and the Core Maintainers are largely the same people which made voting easy.