### PR TITLE
handle newly-commented-out additionalimagestores setting, force the user's UID/GID

### DIFF
--- a/aio/Containerfile
+++ b/aio/Containerfile
@@ -1,17 +1,34 @@
 # aio/Containerfile
 #
-# Build an all in one Podman, Buildah, Skopeo container
-# image from the latest stable version of Podman on the
-# Fedoras Updates System.
+# Build an all-in-one Podman+Buildah+Skopeo container image from the latest
+# stable versions in the Fedoras Updates System.
+#
+# FLAVOR defaults to stable if unset
+#
+# FLAVOR=stable    acquires stable versions of packages
+#                   from the Fedoras Updates System.
+# FLAVOR=testing   acquires testing versions of packages
+#                   from the Fedoras Updates System.
+# FLAVOR=upstream  acquires testing versions of packages
+#                   from the Fedora Copr Buildsystem.
+#                   https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/
+#
 # https://bodhi.fedoraproject.org/updates/?search=podman
 # https://bodhi.fedoraproject.org/updates/?search=buildah
 # https://bodhi.fedoraproject.org/updates/?search=skopeo
-# This image is intended to be used as-is, or as a base-
-# image for development work or use in CI/CD systems.
+#
+# This image can be used to create a container that runs safely with the
+# default set of privileges granted to the container.
 
-FROM registry.fedoraproject.org/fedora-minimal:latest
+FROM registry.fedoraproject.org/fedora:latest
 
 ARG SOURCE_DATE_EPOCH
+
+ARG FLAVOR=stable
+
+ARG UUSER=user
+
+LABEL "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,SYS_CHROOT"
 
 # When building for multiple-architectures in parallel using emulation
 # it's really easy for one/more dnf processes to timeout or mis-count
@@ -22,48 +39,126 @@ RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
 
 ARG INSTALL_RPMS="podman buildah skopeo fuse-overlayfs openssh-clients cpp git-core ${SOURCE_DATE_EPOCH:+sqlite}"
 
-RUN microdnf -y makecache && \
-    microdnf -y update && \
-    microdnf -y install $INSTALL_RPMS \
-        --exclude "container-selinux,qemu-*" && \
+# Don't include container-selinux or any qemu packages, and remove directories
+# used by dnf that are just taking up space.
+# TODO: rpm --setcaps... needed due to Fedora (base) image builds
+#       being (maybe still?) affected by
+#       https://bugzilla.redhat.com/show_bug.cgi?id=1995337#c3
+RUN dnf -y makecache && \
+    dnf -y update && \
     rpm --setcaps shadow-utils 2>/dev/null && \
-    microdnf clean all && \
+    case "${FLAVOR}" in \
+      stable) \
+        dnf -y install $INSTALL_RPMS \
+            --exclude="container-selinux,qemu-*" \
+      ;; \
+      testing) \
+        dnf -y install $INSTALL_RPMS \
+            --exclude="container-selinux,qemu-*" \
+            --enablerepo=updates-testing \
+      ;; \
+      upstream) \
+        dnf -y install 'dnf-command(copr)' --enablerepo=updates-testing && \
+        dnf -y copr enable rhcontainerbot/podman-next && \
+        dnf -y install $INSTALL_RPMS \
+            --exclude="container-selinux,qemu-*" \
+            --enablerepo=updates-testing \
+      ;; \
+      *) \
+        printf "\\nFLAVOR argument must be set and valid, currently: '${FLAVOR}'\\n\\n" 1>&2 && \
+        exit 1 \
+      ;; \
+    esac && \
+    dnf clean all && \
+    latest=$(rpm -qa --qf '%{buildtime}\n' | sort | tail -n 1) ; \
+    echo SOURCE_DATE_EPOCH=${latest} ; \
     if test -n "$SOURCE_DATE_EPOCH" ; then \
+        test "$latest" -eq "${SOURCE_DATE_EPOCH}" ; \
         sqlite3 /usr/lib/sysimage/libdnf5/transaction_history.sqlite "UPDATE trans SET dt_begin=$SOURCE_DATE_EPOCH, dt_end=$SOURCE_DATE_EPOCH; PRAGMA journal_mode=DELETE; PRAGMA journal_mode=WAL" ; \
     fi && \
     rm -fv /etc/machine-id /var/lib/systemd/random-seed /var/lib/dnf/repos/*/countme && \
     rm -fv /usr/lib/systemd/profile.d/* && \
-    rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+    rm -rf /var/cache/*/* /var/log/dnf* /var/log/yum.*
 
-# It's assumed `user` will end up with UID/GID 1000
-RUN useradd user && \
-    echo -e "root:1:65535\nuser:1:999\nuser:1001:64535" > /etc/subuid && \
-    echo -e "root:1:65535\nuser:1:999\nuser:1001:64535" > /etc/subgid
+# Copy & modify the system-wide defaults: use fuse-overlay storage.
+COPY --chmod=644 containers.conf /etc/containers/containers.conf
+RUN case "${FLAVOR}" in \
+      stable|testing) \
+          sed -e 's|^#mount_program|mount_program|g' \
+              -e '/^ *additionalimagestores = \[$/a "/var/lib/shared",' \
+              -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
+              /usr/share/containers/storage.conf \
+              > /etc/containers/storage.conf ; \
+          chmod 644 /etc/containers/storage.conf ; \
+      ;; \
+      upstream) \
+          mkdir -p /etc/containers/containers.rootful.conf.d ; \
+          mv /etc/containers/containers.conf /etc/containers/containers.rootful.conf.d/20-image_build.conf ; \
+          mkdir -p /etc/containers/storage.rootful.conf.d ; \
+          echo '[storage]' > /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'driver = "overlay"' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo '[storage.options]' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'additionalimagestores = ["/usr/lib/containers/storage","/var/lib/shared"]' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo '[storage.overlay]' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'mount_program = "/usr/bin/fuse-overlayfs"' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'mountopt= "nodev,fsync=0"' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+      ;; \
+      *) \
+        printf "\\nFLAVOR argument must be set and valid, currently: '${FLAVOR}'\\n\\n" 1>&2 && \
+        exit 1 \
+      ;; \
+    esac
 
-ADD /containers.conf /etc/containers/containers.conf
-ADD /user-containers.conf /home/user/.config/containers/containers.conf
+# Force `user` to end up with UID/GID 1000, set up some ID mappings, and create
+# directories that they will need to be able to write to.
+RUN groupadd -g 1000 $UUSER && useradd -u 1000 -g 1000 $UUSER && \
+    echo -e "root:1:65535\n$UUSER:1:999\n$UUSER:1001:64535" > /etc/subuid && \
+    echo -e "root:1:65535\n$UUSER:1:999\n$UUSER:1001:64535" > /etc/subgid && \
+    mkdir -p /home/$UUSER/.local/share/containers && \
+    mkdir -p /home/$UUSER/.config/containers && \
+    mkdir -p /run/user/1000 && \
+    chown -R $UUSER:$UUSER /home/$UUSER /run/user/1000
 
-RUN mkdir -p /home/user/.local/share/containers && \
-    mkdir -p /home/user/.config/containers && \
-    chown user:user -R /home/user && \
-    chmod 644 /etc/containers/containers.conf
+# Create modified configurations for the unprivileged user.
+COPY --chmod=644 user-containers.conf /home/$UUSER/.config/containers/containers.conf
+RUN case "${FLAVOR}" in \
+      stable|testing) \
+          sed -e 's|^graphroot|# graphroot|g' \
+              -e 's|^runroot|# runroot|g' \
+              -e '/^ *\"\/usr\/lib\/containers\/storage\" *, *$/d' \
+              /etc/containers/storage.conf \
+              > /home/$UUSER/.config/containers/storage.conf ; \
+          chmod 644 /home/$UUSER/.config/containers/storage.conf ; \
+      ;; \
+      upstream) \
+          mkdir -p /etc/containers/containers.rootless.conf.d ; \
+          mv /home/$UUSER/.config/containers/containers.conf /etc/containers/containers.rootless.conf.d/20-image_build.conf ; \
+          mkdir -p /etc/containers/storage.rootless.conf.d ; \
+          echo '[storage]' > /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'driver = "overlay"' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo '[storage.options]' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'additionalimagestores = ["/var/lib/shared"]' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo '[storage.overlay]' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'mount_program = "/usr/bin/fuse-overlayfs"' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'mountopt= "nodev,fsync=0"' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+      ;; \
+      *) \
+        printf "\\nFLAVOR argument must be set and valid, currently: '${FLAVOR}'\\n\\n" 1>&2 && \
+        exit 1 \
+      ;; \
+    esac && \
+    chown -R $UUSER:$UUSER /home/$UUSER
 
-# Copy & modify the defaults to provide reference if runtime changes needed.
-# Changes here are required for running with fuse-overlay storage inside container.
-RUN sed -e 's|^#mount_program|mount_program|g' \
-        -e '/additionalimage.*/a "/var/lib/shared",' \
-        -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
-        /usr/share/containers/storage.conf \
-        > /etc/containers/storage.conf
-
-# Setup internal Podman to pass subscriptions down from host to internal container
+# Setup internal Podman and Buildah to pass secrets/subscriptions that are
+# passed down from the host on down to commands and builds that they run.
 RUN printf '/run/secrets/etc-pki-entitlement:/run/secrets/etc-pki-entitlement\n/run/secrets/rhsm:/run/secrets/rhsm\n' > /etc/containers/mounts.conf
 
 # Note VOLUME options must always happen after the chown call above
-# RUN commands can not modify existing volumes
+# Way back when, RUN commands could not modify existing volumes
 VOLUME /var/lib/containers
-VOLUME /home/user/.local/share/containers
+VOLUME /home/$UUSER/.local/share/containers
 
+# Setup the ability to use additional stores with this container image.
 RUN mkdir -p /var/lib/shared/overlay-images \
              /var/lib/shared/overlay-layers \
              /var/lib/shared/vfs-images \
@@ -73,5 +168,6 @@ RUN mkdir -p /var/lib/shared/overlay-images \
     touch /var/lib/shared/vfs-images/images.lock && \
     touch /var/lib/shared/vfs-layers/layers.lock
 
-ENV _CONTAINERS_USERNS_CONFIGURED="" \
-    BUILDAH_ISOLATION=chroot
+# Set an environment variable to default to chroot isolation for RUN
+# instructions during builds and "buildah run".
+ENV BUILDAH_ISOLATION=chroot

--- a/buildah/Containerfile
+++ b/buildah/Containerfile
@@ -1,7 +1,7 @@
 # buildah/Containerfile
 #
-# Build a Buildah container image from the latest version
-# of Fedora.
+# Build a Buildah container image from the latest stable version in the Fedoras
+# Updates System.
 #
 # FLAVOR defaults to stable if unset
 #
@@ -15,9 +15,8 @@
 #
 # https://bodhi.fedoraproject.org/updates/?search=buildah
 #
-# This image can be used to create a secured container
-# that runs safely with privileges within the container.
-#
+# This image can be used to create a container that runs safely with the
+# default set of privileges granted to the container.
 
 FROM registry.fedoraproject.org/fedora:latest
 
@@ -25,7 +24,9 @@ ARG SOURCE_DATE_EPOCH
 
 ARG FLAVOR=stable
 
-LABEL "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,SYS_CHROOT"
+ARG UUSER=build
+
+LABEL "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,SYS_CHROOT"
 
 # When building for multiple-architectures in parallel using emulation
 # it's really easy for one/more dnf processes to timeout or mis-count
@@ -36,9 +37,8 @@ RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
 
 ARG INSTALL_RPMS="buildah fuse-overlayfs cpp git-core ${SOURCE_DATE_EPOCH:+sqlite}"
 
-# Don't include container-selinux and remove
-# directories used by dnf that are just taking
-# up space.
+# Don't include container-selinux, and remove directories used by dnf that are
+# just taking up space.
 # TODO: rpm --setcaps... needed due to Fedora (base) image builds
 #       being (maybe still?) affected by
 #       https://bugzilla.redhat.com/show_bug.cgi?id=1995337#c3
@@ -47,48 +47,113 @@ RUN dnf -y makecache && \
     rpm --setcaps shadow-utils 2>/dev/null && \
     case "${FLAVOR}" in \
       stable) \
-        dnf -y install $INSTALL_RPMS --exclude container-selinux \
+        dnf -y install $INSTALL_RPMS \
+            --exclude=container-selinux \
       ;; \
       testing) \
-        dnf -y install $INSTALL_RPMS --exclude container-selinux \
+        dnf -y install $INSTALL_RPMS \
+            --exclude=container-selinux \
             --enablerepo=updates-testing \
       ;; \
       upstream) \
         dnf -y install 'dnf-command(copr)' --enablerepo=updates-testing && \
         dnf -y copr enable rhcontainerbot/podman-next && \
         dnf -y install $INSTALL_RPMS \
-            --exclude container-selinux \
-            --enablerepo=updates-testing  \
+            --exclude=container-selinux \
+            --enablerepo=updates-testing \
       ;; \
       *) \
         printf "\\nFLAVOR argument must be set and valid, currently: '${FLAVOR}'\\n\\n" 1>&2 && \
         exit 1 \
       ;; \
     esac && \
-    dnf -y clean all && \
+    dnf clean all && \
+    latest=$(rpm -qa --qf '%{buildtime}\n' | sort | tail -n 1) ; \
+    echo SOURCE_DATE_EPOCH=${latest} ; \
     if test -n "$SOURCE_DATE_EPOCH" ; then \
+        test "$latest" -eq "${SOURCE_DATE_EPOCH}" ; \
         sqlite3 /usr/lib/sysimage/libdnf5/transaction_history.sqlite "UPDATE trans SET dt_begin=$SOURCE_DATE_EPOCH, dt_end=$SOURCE_DATE_EPOCH; PRAGMA journal_mode=DELETE; PRAGMA journal_mode=WAL" ; \
     fi && \
     rm -fv /etc/machine-id /var/lib/systemd/random-seed /var/lib/dnf/repos/*/countme && \
     rm -fv /usr/lib/systemd/profile.d/* && \
-    rm -rf /var/cache/*/* /var/log/dnf* /var/log/hawkey.log /var/log/yum.*
+    rm -rf /var/cache/*/* /var/log/dnf* /var/log/yum.*
 
+# Copy & modify the system-wide defaults: use fuse-overlay storage.
+COPY --chmod=644 containers.conf /etc/containers/containers.conf
+RUN case "${FLAVOR}" in \
+      stable|testing) \
+          sed -e 's|^#mount_program|mount_program|g' \
+              -e '/^ *additionalimagestores = \[$/a "/var/lib/shared",' \
+              -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
+              /usr/share/containers/storage.conf \
+              > /etc/containers/storage.conf ; \
+          chmod 644 /etc/containers/storage.conf ; \
+      ;; \
+      upstream) \
+          mkdir -p /etc/containers/containers.rootful.conf.d ; \
+          mv /etc/containers/containers.conf /etc/containers/containers.rootful.conf.d/20-image_build.conf ; \
+          mkdir -p /etc/containers/storage.rootful.conf.d ; \
+          echo '[storage]' > /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'driver = "overlay"' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo '[storage.options]' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'additionalimagestores = ["/usr/lib/containers/storage","/var/lib/shared"]' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo '[storage.overlay]' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'mount_program = "/usr/bin/fuse-overlayfs"' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'mountopt= "nodev,fsync=0"' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+      ;; \
+      *) \
+        printf "\\nFLAVOR argument must be set and valid, currently: '${FLAVOR}'\\n\\n" 1>&2 && \
+        exit 1 \
+      ;; \
+    esac
 
-ADD ./containers.conf /etc/containers/
+# Force `build` to end up with UID/GID 1000, set up some ID mappings, and
+# create directories that they will need to be able to write to.
+RUN groupadd -g 1000 $UUSER && useradd -u 1000 -g 1000 $UUSER && \
+    echo -e "root:1:65535\n$UUSER:1:999\n$UUSER:1001:64535" > /etc/subuid && \
+    echo -e "root:1:65535\n$UUSER:1:999\n$UUSER:1001:64535" > /etc/subgid && \
+    mkdir -p /home/$UUSER/.local/share/containers && \
+    mkdir -p /home/$UUSER/.config/containers && \
+    mkdir -p /run/user/1000 && \
+    chown -R $UUSER:$UUSER /home/$UUSER /run/user/1000
 
-# Setup internal Buildah to pass secrets/subscriptions down from host to internal container
+# Create modified configurations for the unprivileged user.
+RUN case "${FLAVOR}" in \
+      stable|testing) \
+          sed -e 's|^graphroot|# graphroot|g' \
+              -e 's|^runroot|# runroot|g' \
+              -e '/^ *\"\/usr\/lib\/containers\/storage\" *, *$/d' \
+              /etc/containers/storage.conf \
+              > /home/$UUSER/.config/containers/storage.conf ; \
+          chmod 644 /home/$UUSER/.config/containers/storage.conf ; \
+      ;; \
+      upstream) \
+          mkdir -p /etc/containers/storage.rootless.conf.d ; \
+          echo '[storage]' > /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'driver = "overlay"' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo '[storage.options]' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'additionalimagestores = ["/var/lib/shared"]' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo '[storage.overlay]' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'mount_program = "/usr/bin/fuse-overlayfs"' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'mountopt= "nodev,fsync=0"' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+      ;; \
+      *) \
+        printf "\\nFLAVOR argument must be set and valid, currently: '${FLAVOR}'\\n\\n" 1>&2 && \
+        exit 1 \
+      ;; \
+    esac && \
+    chown -R $UUSER:$UUSER /home/$UUSER
+
+# Setup internal Buildah to pass secrets/subscriptions that are passed down from
+# the host on down to builds it runs.
 RUN printf '/run/secrets/etc-pki-entitlement:/run/secrets/etc-pki-entitlement\n/run/secrets/rhsm:/run/secrets/rhsm\n' > /etc/containers/mounts.conf
 
-# Copy & modify the defaults to provide reference if runtime changes needed.
-# Changes here are required for running with fuse-overlay storage inside container.
-RUN sed -e 's|^#mount_program|mount_program|g' \
-        -e '/additionalimage.*/a "/var/lib/shared",' \
-        -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
-        /usr/share/containers/storage.conf \
-        > /etc/containers/storage.conf && \
-    chmod 644 /etc/containers/storage.conf && \
-    chmod 644 /etc/containers/containers.conf
+# Note VOLUME options must always happen after the chown call above
+# Way back when, RUN commands could not modify existing volumes
+VOLUME /var/lib/containers
+VOLUME /home/$UUSER/.local/share/containers
 
+# Setup the ability to use additional stores with this container image.
 RUN mkdir -p /var/lib/shared/overlay-images \
              /var/lib/shared/overlay-layers \
              /var/lib/shared/vfs-images \
@@ -97,28 +162,6 @@ RUN mkdir -p /var/lib/shared/overlay-images \
     touch /var/lib/shared/overlay-layers/layers.lock && \
     touch /var/lib/shared/vfs-images/images.lock && \
     touch /var/lib/shared/vfs-layers/layers.lock
-
-# Define uid/gid ranges for our user https://github.com/containers/buildah/issues/3053
-# It's assumed `build` will end up with UID/GID 1000
-RUN useradd build && \
-    echo -e "root:1:65535\nbuild:1:999\nbuild:1001:64535" > /etc/subuid && \
-    echo -e "root:1:65535\nbuild:1:999\nbuild:1001:64535" > /etc/subgid && \
-    mkdir -p /home/build/.local/share/containers && \
-    mkdir -p /home/build/.config/containers && \
-    chown -R build:build /home/build
-# See:  https://github.com/containers/buildah/issues/4669
-# Copy & modify the config for the `build` user and remove the global
-# `runroot` and `graphroot` which current `build` user cannot access,
-# in such case storage will choose a runroot in `/var/tmp`.
-RUN sed -e 's|^#mount_program|mount_program|g' \
-        -e 's|^graphroot|#graphroot|g' \
-        -e 's|^runroot|#runroot|g' \
-        /etc/containers/storage.conf \
-        > /home/build/.config/containers/storage.conf && \
-        chown build:build /home/build/.config/containers/storage.conf
-
-VOLUME /var/lib/containers
-VOLUME /home/build/.local/share/containers
 
 # Set an environment variable to default to chroot isolation for RUN
 # instructions and "buildah run".

--- a/podman/Containerfile
+++ b/podman/Containerfile
@@ -1,10 +1,7 @@
 # podman/Containerfile
 #
-# Build a Podman container image from the latest
-# stable version of Podman on the Fedoras Updates System.
-# https://bodhi.fedoraproject.org/updates/?search=podman
-# This image can be used to create a secured container
-# that runs safely with privileges within the container.
+# Build a Podman container image from the latest stable version in the Fedoras
+# Updates System.
 #
 # FLAVOR defaults to stable if unset
 #
@@ -17,12 +14,19 @@
 #                   https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/
 #
 # https://bodhi.fedoraproject.org/updates/?search=podman
+#
+# This image can be used to create a container that runs safely with the
+# default set of privileges granted to the container.
 
 FROM registry.fedoraproject.org/fedora:latest
 
 ARG SOURCE_DATE_EPOCH
 
 ARG FLAVOR=stable
+
+ARG UUSER=podman
+
+LABEL "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,SYS_CHROOT"
 
 # When building for multiple-architectures in parallel using emulation
 # it's really easy for one/more dnf processes to timeout or mis-count
@@ -33,9 +37,8 @@ RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
 
 ARG INSTALL_RPMS="podman fuse-overlayfs openssh-clients cpp git-core ${SOURCE_DATE_EPOCH:+sqlite}"
 
-# Don't include container-selinux and remove
-# directories used by dnf that are just taking
-# up space.
+# Don't include container-selinux, and remove directories used by dnf that are
+# just taking up space.
 # TODO: rpm --setcaps... needed due to Fedora (base) image builds
 #       being (maybe still?) affected by
 #       https://bugzilla.redhat.com/show_bug.cgi?id=1995337#c3
@@ -44,17 +47,19 @@ RUN dnf -y makecache && \
     rpm --setcaps shadow-utils 2>/dev/null && \
     case "${FLAVOR}" in \
       stable) \
-        dnf -y install $INSTALL_RPMS --exclude container-selinux \
+        dnf -y install $INSTALL_RPMS \
+            --exclude=container-selinux \
       ;; \
       testing) \
-        dnf -y install $INSTALL_RPMS --exclude container-selinux \
-            --enablerepo updates-testing \
+        dnf -y install $INSTALL_RPMS \
+            --exclude=container-selinux \
+            --enablerepo=updates-testing \
       ;; \
       upstream) \
         dnf -y install 'dnf-command(copr)' --enablerepo=updates-testing && \
         dnf -y copr enable rhcontainerbot/podman-next && \
         dnf -y install $INSTALL_RPMS \
-            --exclude container-selinux \
+            --exclude=container-selinux \
             --enablerepo=updates-testing \
       ;; \
       *) \
@@ -63,41 +68,95 @@ RUN dnf -y makecache && \
       ;; \
     esac && \
     dnf clean all && \
+    latest=$(rpm -qa --qf '%{buildtime}\n' | sort | tail -n 1) ; \
+    echo SOURCE_DATE_EPOCH=${latest} ; \
     if test -n "$SOURCE_DATE_EPOCH" ; then \
+        test "$latest" -eq "${SOURCE_DATE_EPOCH}" ; \
         sqlite3 /usr/lib/sysimage/libdnf5/transaction_history.sqlite "UPDATE trans SET dt_begin=$SOURCE_DATE_EPOCH, dt_end=$SOURCE_DATE_EPOCH; PRAGMA journal_mode=DELETE; PRAGMA journal_mode=WAL" ; \
     fi && \
     rm -fv /etc/machine-id /var/lib/systemd/random-seed /var/lib/dnf/repos/*/countme && \
     rm -fv /usr/lib/systemd/profile.d/* && \
-    rm -rf /var/cache /var/log/dnf* /var/log/hawkey.log /var/log/yum.*
+    rm -rf /var/cache/*/* /var/log/dnf* /var/log/yum.*
 
-# It's assumed `podman` will end up with UID/GID 1000
-RUN useradd podman && \
-    echo -e "root:1:65535\npodman:1:999\npodman:1001:64535" > /etc/subuid && \
-    echo -e "root:1:65535\npodman:1:999\npodman:1001:64535" > /etc/subgid
+# Copy & modify the system-wide defaults: use fuse-overlay storage.
+COPY --chmod=644 containers.conf /etc/containers/containers.conf
+RUN case "${FLAVOR}" in \
+      stable|testing) \
+          sed -e 's|^#mount_program|mount_program|g' \
+              -e '/^ *additionalimagestores = \[$/a "/var/lib/shared",' \
+              -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
+              /usr/share/containers/storage.conf \
+              > /etc/containers/storage.conf ; \
+          chmod 644 /etc/containers/storage.conf ; \
+      ;; \
+      upstream) \
+          mkdir -p /etc/containers/containers.rootful.conf.d ; \
+          mv /etc/containers/containers.conf /etc/containers/containers.rootful.conf.d/20-image_build.conf ; \
+          mkdir -p /etc/containers/storage.rootful.conf.d ; \
+          echo '[storage]' > /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'driver = "overlay"' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo '[storage.options]' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'additionalimagestores = ["/usr/lib/containers/storage","/var/lib/shared"]' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo '[storage.overlay]' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'mount_program = "/usr/bin/fuse-overlayfs"' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'mountopt= "nodev,fsync=0"' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+      ;; \
+      *) \
+        printf "\\nFLAVOR argument must be set and valid, currently: '${FLAVOR}'\\n\\n" 1>&2 && \
+        exit 1 \
+      ;; \
+    esac
 
-ADD /containers.conf /etc/containers/containers.conf
-ADD /podman-containers.conf /home/podman/.config/containers/containers.conf
+# Force `podman` to end up with UID/GID 1000, set up some ID mappings, and
+# create directories that they will need to be able to write to.
+RUN groupadd -g 1000 $UUSER && useradd -u 1000 -g 1000 $UUSER && \
+    echo -e "root:1:65535\n$UUSER:1:999\n$UUSER:1001:64535" > /etc/subuid && \
+    echo -e "root:1:65535\n$UUSER:1:999\n$UUSER:1001:64535" > /etc/subgid && \
+    mkdir -p /home/$UUSER/.local/share/containers && \
+    mkdir -p /home/$UUSER/.config/containers && \
+    mkdir -p /run/user/1000 && \
+    chown -R $UUSER:$UUSER /home/$UUSER /run/user/1000
 
-RUN mkdir -p /home/podman/.local/share/containers && \
-    chown podman:podman -R /home/podman && \
-    chmod 644 /etc/containers/containers.conf
+# Create modified configurations for the unprivileged user.
+COPY --chmod=644 podman-containers.conf /home/$UUSER/.config/containers/containers.conf
+RUN case "${FLAVOR}" in \
+      stable|testing) \
+          sed -e 's|^graphroot|# graphroot|g' \
+              -e 's|^runroot|# runroot|g' \
+              -e '/^ *\"\/usr\/lib\/containers\/storage\" *, *$/d' \
+              /etc/containers/storage.conf \
+              > /home/$UUSER/.config/containers/storage.conf ; \
+          chmod 644 /home/$UUSER/.config/containers/storage.conf ; \
+      ;; \
+      upstream) \
+          mkdir -p /etc/containers/containers.rootless.conf.d ; \
+          mv /home/$UUSER/.config/containers/containers.conf /etc/containers/containers.rootless.conf.d/20-image_build.conf ; \
+          mkdir -p /etc/containers/storage.rootless.conf.d ; \
+          echo '[storage]' > /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'driver = "overlay"' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo '[storage.options]' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'additionalimagestores = ["/var/lib/shared"]' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo '[storage.overlay]' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'mount_program = "/usr/bin/fuse-overlayfs"' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'mountopt= "nodev,fsync=0"' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+      ;; \
+      *) \
+        printf "\\nFLAVOR argument must be set and valid, currently: '${FLAVOR}'\\n\\n" 1>&2 && \
+        exit 1 \
+      ;; \
+    esac && \
+    chown -R $UUSER:$UUSER /home/$UUSER
 
-# Copy & modify the defaults to provide reference if runtime changes needed.
-# Changes here are required for running with fuse-overlay storage inside container.
-RUN sed -e 's|^#mount_program|mount_program|g' \
-           -e '/additionalimage.*/a "/var/lib/shared",' \
-           -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
-           /usr/share/containers/storage.conf \
-           > /etc/containers/storage.conf
-
-# Setup internal Podman to pass subscriptions down from host to internal container
+# Setup internal Podman to pass secrets/subscriptions that are passed down from
+# the host on down to commands it runs.
 RUN printf '/run/secrets/etc-pki-entitlement:/run/secrets/etc-pki-entitlement\n/run/secrets/rhsm:/run/secrets/rhsm\n' > /etc/containers/mounts.conf
 
 # Note VOLUME options must always happen after the chown call above
-# RUN commands can not modify existing volumes
+# Way back when, RUN commands could not modify existing volumes
 VOLUME /var/lib/containers
-VOLUME /home/podman/.local/share/containers
+VOLUME /home/$UUSER/.local/share/containers
 
+# Setup the ability to use additional stores with this container image.
 RUN mkdir -p /var/lib/shared/overlay-images \
              /var/lib/shared/overlay-layers \
              /var/lib/shared/vfs-images \
@@ -107,5 +166,6 @@ RUN mkdir -p /var/lib/shared/overlay-images \
     touch /var/lib/shared/vfs-images/images.lock && \
     touch /var/lib/shared/vfs-layers/layers.lock
 
-ENV _CONTAINERS_USERNS_CONFIGURED="" \
-    BUILDAH_ISOLATION=chroot
+# Set an environment variable to default to chroot isolation for RUN
+# instructions.
+ENV BUILDAH_ISOLATION=chroot

--- a/skopeo/Containerfile
+++ b/skopeo/Containerfile
@@ -3,8 +3,6 @@
 # Build a Skopeo container image from the latest
 # stable version of Skopeo on the Fedoras Updates System.
 # https://bodhi.fedoraproject.org/updates/?search=skopeo
-# This image can be used to create a secured container
-# that runs safely with privileges within the container.
 #
 # FLAVOR defaults to stable if unset
 #
@@ -17,12 +15,19 @@
 #                   https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/
 #
 # https://bodhi.fedoraproject.org/updates/?search=skopeo
+#
+# This image can be used to create a container that runs safely with the
+# default set of privileges granted to the container.
 
 FROM registry.fedoraproject.org/fedora:latest
 
 ARG SOURCE_DATE_EPOCH
 
 ARG FLAVOR=stable
+
+ARG UUSER=skopeo
+
+LABEL "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,SYS_CHROOT"
 
 # When building for multiple-architectures in parallel using emulation
 # it's really easy for one/more dnf processes to timeout or mis-count
@@ -33,27 +38,29 @@ RUN echo -e "\n\n# Added during image build" >> /etc/dnf/dnf.conf && \
 
 ARG INSTALL_RPMS="skopeo fuse-overlayfs ${SOURCE_DATE_EPOCH:+sqlite}"
 
-# Don't include container-selinux and remove
-# directories used by dnf that are just taking
-# up space.
+# Don't include container-selinux, and remove directories used by dnf that are
+# just taking up space.
 # TODO: rpm --setcaps... needed due to Fedora (base) image builds
 #       being (maybe still?) affected by
 #       https://bugzilla.redhat.com/show_bug.cgi?id=1995337#c3
-RUN dnf -y update && \
+RUN dnf -y makecache && \
+    dnf -y update && \
     rpm --setcaps shadow-utils 2>/dev/null && \
     case "${FLAVOR}" in \
       stable) \
-        dnf -y install $INSTALL_RPMS --exclude container-selinux \
+        dnf -y install $INSTALL_RPMS \
+            --exclude=container-selinux \
       ;; \
       testing) \
-        dnf -y install $INSTALL_RPMS --exclude container-selinux \
-            --enablerepo updates-testing \
+        dnf -y install $INSTALL_RPMS \
+            --exclude=container-selinux \
+            --enablerepo=updates-testing \
       ;; \
       upstream) \
         dnf -y install 'dnf-command(copr)' --enablerepo=updates-testing && \
         dnf -y copr enable rhcontainerbot/podman-next && \
         dnf -y install $INSTALL_RPMS \
-            --exclude container-selinux \
+            --exclude=container-selinux \
             --enablerepo=updates-testing \
       ;; \
       *) \
@@ -62,32 +69,88 @@ RUN dnf -y update && \
       ;; \
     esac && \
     dnf clean all && \
+    latest=$(rpm -qa --qf '%{buildtime}\n' | sort | tail -n 1) ; \
+    echo SOURCE_DATE_EPOCH=${latest} ; \
     if test -n "$SOURCE_DATE_EPOCH" ; then \
+        test "$latest" -eq "${SOURCE_DATE_EPOCH}" ; \
         sqlite3 /usr/lib/sysimage/libdnf5/transaction_history.sqlite "UPDATE trans SET dt_begin=$SOURCE_DATE_EPOCH, dt_end=$SOURCE_DATE_EPOCH; PRAGMA journal_mode=DELETE; PRAGMA journal_mode=WAL" ; \
     fi && \
     rm -fv /etc/machine-id /var/lib/systemd/random-seed /var/lib/dnf/repos/*/countme && \
     rm -fv /usr/lib/systemd/profile.d/* && \
-    rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+    rm -rf /var/cache/*/* /var/log/dnf* /var/log/yum.*
 
-# It's assumed `skopeo` will end up with UID/GID 1000
-RUN useradd skopeo && \
-    echo -e "root:1:65535\nskopeo:1:999\nskopeo:1001:64535" > /etc/subuid && \
-    echo -e "root:1:65535\nskopeo:1:999\nskopeo:1001:64535" > /etc/subgid
+# Copy & modify the system-wide defaults: use fuse-overlay storage.
+RUN case "${FLAVOR}" in \
+      stable|testing) \
+          sed -e 's|^#mount_program|mount_program|g' \
+              -e '/^ *additionalimagestores = \[$/a "/var/lib/shared",' \
+              -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
+              /usr/share/containers/storage.conf \
+              > /etc/containers/storage.conf ; \
+          chmod 644 /etc/containers/storage.conf ; \
+      ;; \
+      upstream) \
+          mkdir -p /etc/containers/storage.rootful.conf.d ; \
+          echo '[storage]' > /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'driver = "overlay"' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo '[storage.options]' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'additionalimagestores = ["/usr/lib/containers/storage","/var/lib/shared"]' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo '[storage.overlay]' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'mount_program = "/usr/bin/fuse-overlayfs"' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+          echo 'mountopt= "nodev,fsync=0"' >> /etc/containers/storage.rootful.conf.d/20-image_build.conf ; \
+      ;; \
+      *) \
+        printf "\\nFLAVOR argument must be set and valid, currently: '${FLAVOR}'\\n\\n" 1>&2 && \
+        exit 1 \
+      ;; \
+    esac
 
-# Copy & modify the defaults to provide reference if runtime changes needed.
-# Changes here are required for running with fuse-overlay storage inside container.
-RUN sed -e 's|^#mount_program|mount_program|g' \
-        -e '/additionalimage.*/a "/var/lib/shared",' \
-        -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
-        /usr/share/containers/storage.conf \
-        > /etc/containers/storage.conf
+# Force `skopeo` to end up with UID/GID 1000, set up some ID mappings, and
+# create directories that they might need to be able to write to.
+RUN groupadd -g 1000 $UUSER && useradd -u 1000 -g 1000 $UUSER && \
+    echo -e "root:1:65535\n$UUSER:1:999\n$UUSER:1001:64535" > /etc/subuid && \
+    echo -e "root:1:65535\n$UUSER:1:999\n$UUSER:1001:64535" > /etc/subgid && \
+    mkdir -p /home/$UUSER/.local/share/containers && \
+    mkdir -p /home/$UUSER/.config/containers && \
+    mkdir -p /run/user/1000 && \
+    chown -R $UUSER:$UUSER /home/$UUSER /run/user/1000
 
-# Setup the ability to use additional stores
-# with this container image.
+# Create modified configurations for the unprivileged user.
+RUN case "${FLAVOR}" in \
+      stable|testing) \
+          sed -e 's|^graphroot|# graphroot|g' \
+              -e 's|^runroot|# runroot|g' \
+              -e '/^ *\"\/usr\/lib\/containers\/storage\" *, *$/d' \
+              /etc/containers/storage.conf \
+              > /home/$UUSER/.config/containers/storage.conf ; \
+          chmod 644 /home/$UUSER/.config/containers/storage.conf ; \
+      ;; \
+      upstream) \
+          mkdir -p /etc/containers/storage.rootless.conf.d ; \
+          echo '[storage]' > /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'driver = "overlay"' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo '[storage.options]' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'additionalimagestores = ["/var/lib/shared"]' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo '[storage.overlay]' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'mount_program = "/usr/bin/fuse-overlayfs"' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+          echo 'mountopt= "nodev,fsync=0"' >> /etc/containers/storage.rootless.conf.d/20-image_build.conf ; \
+      ;; \
+      *) \
+        printf "\\nFLAVOR argument must be set and valid, currently: '${FLAVOR}'\\n\\n" 1>&2 && \
+        exit 1 \
+      ;; \
+    esac && \
+    chown -R $UUSER:$UUSER /home/$UUSER
+
+# Setup the ability to use additional stores with this container image.
 RUN mkdir -p /var/lib/shared/overlay-images \
-             /var/lib/shared/overlay-layers && \
+             /var/lib/shared/overlay-layers \
+             /var/lib/shared/vfs-images \
+             /var/lib/shared/vfs-layers && \
     touch /var/lib/shared/overlay-images/images.lock && \
-    touch /var/lib/shared/overlay-layers/layers.lock
+    touch /var/lib/shared/overlay-layers/layers.lock && \
+    touch /var/lib/shared/vfs-images/images.lock && \
+    touch /var/lib/shared/vfs-layers/layers.lock
 
 # Point to the Authorization file
 ENV REGISTRY_AUTH_FILE=/tmp/auth.json


### PR DESCRIPTION
Have the "upstream" flavors of the image builds configured using /etc/containers/{containers,storage}-{rootless,rootful}.conf.d, as appropriate.  It's a bit clunky right now because we have to conditionalize it in shell, but at some point we'll be able to replace that with COPY with or without heredocs.

Remove the /usr/lib/containers/storage additional image store from the storage.conf that we create for the unprivileged users that the images include.
Fixes #64

Switch the "aio" image to using the full Fedora image as its base, to match the others.

Instead of just expecting the unprivileged user that we create to end up with UID=1000:GID=1000, force it.  Use an ARG for the user name, so that more of the rest of the logic will look the same in all of them.

Reorder the copying in of containers.conf files, the creation of the unprivileged user, their configuration files, and the mounts.conf, so that more of the rest of the logic will look the same in all of them.

Create the same set of locks under the /var/lib/shared additional image store in all images, and do so right after defining volumes and before the final setting of environment variables and/or the entrypoint.

Compare SOURCE_DATE_EPOCH, if defined, to the latest %{builddate} among the packages that we end up installing, and print the %{builddate} value so that, worst case, we can build once, then again with the arg defined.